### PR TITLE
fix: resolve Safari download issue by improving URL handling

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -139,13 +139,25 @@ document.getElementById('downloadButton').addEventListener('click', function () 
         document.getElementById('outputText').value = 'Error: No content to download. Please generate the text file first.';
         return;
     }
-    const blob = new Blob([outputText], { type: 'text/plain' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'prompt.txt';
-    a.click();
-    URL.revokeObjectURL(url);
+    
+    try {
+        const blob = new Blob([outputText], { type: 'text/plain' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'prompt.txt';
+        document.body.appendChild(a);
+        a.click();
+        
+        // Clean up after a delay to ensure the download starts
+        setTimeout(() => {
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+        }, 100);
+    } catch (error) {
+        console.error('Error during file download:', error);
+        document.getElementById('outputText').value = `Error: Failed to download file. ${error.message}`;
+    }
 });
 
 // Parse GitHub repository URL


### PR DESCRIPTION
## Description
This PR fixes an issue where file downloads would fail in Safari with the error "Safari Can't Open the Page" when clicking the "Download Text File" button.

## Changes Made
- Added the anchor element to the DOM before triggering the click event
- Added a small delay before URL revocation to ensure download starts
- Improved error handling with try-catch block
- Added proper cleanup of temporary elements

## Testing
- Tested in Safari (macOS)
- Verified downloads work correctly
- Confirmed no regressions in Chrome



before
<img width="519" height="208" alt="Screenshot 2025-08-05 at 23 26 04" src="https://github.com/user-attachments/assets/7d2ecce6-673f-460c-9063-94853c178067" />


after
<img width="542" height="244" alt="Screenshot 2025-08-05 at 23 25 55" src="https://github.com/user-attachments/assets/49783261-8246-4308-9147-afcaac953718" />
