### PR TITLE
feat(ui): rebuild the workspace layout and fix file tree, URL, and API error handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,23 +95,23 @@
       -->
       <div class="min-h-screen flex flex-col bg-gray-50 dark:bg-gray-900">
         <header class="w-full border-b border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900">
-          <div class="container mx-auto flex h-14 sm:h-16 items-center px-3 sm:px-4 lg:px-6">
-            <h1 class="text-lg sm:text-xl md:text-2xl font-bold text-gray-900 dark:text-gray-100">
+          <div class="container mx-auto flex h-14 items-baseline gap-2 sm:gap-3 px-3 sm:px-4 lg:px-6">
+            <h1 class="text-base sm:text-lg font-semibold tracking-tight text-gray-900 dark:text-gray-100">
               repo2txt
             </h1>
-            <span class="ml-2 rounded-full bg-primary-100 dark:bg-primary-900 px-2 py-0.5 text-xs font-semibold text-primary-700 dark:text-primary-300">
-              v2.0 Beta
+            <span class="rounded border border-gray-300 dark:border-gray-700 px-1.5 py-px text-[11px] font-medium text-gray-500 dark:text-gray-400">
+              v2.0 beta
             </span>
           </div>
         </header>
-        <main class="flex-1 container mx-auto px-3 sm:px-4 lg:px-6 py-6 md:py-8">
-          <section class="mx-auto max-w-3xl space-y-2 text-center" aria-labelledby="initial-heading">
-            <h2 id="initial-heading" class="text-xl sm:text-2xl md:text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-100">
+        <main class="flex-1 container mx-auto px-3 sm:px-4 lg:px-6">
+          <section class="mx-auto max-w-2xl space-y-3 py-10 sm:py-14 text-center" aria-labelledby="initial-heading">
+            <h2 id="initial-heading" class="text-2xl sm:text-3xl font-semibold tracking-tight text-gray-900 dark:text-gray-100">
               Convert repositories to plain text for LLMs
             </h2>
             <p class="text-sm sm:text-base text-gray-600 dark:text-gray-400">
-              Turn GitHub, GitLab, Azure DevOps, local folders, or ZIP files into clean,
-              copy-ready context for AI tools—entirely in your browser.
+              GitHub, GitLab, Azure DevOps, local folders, and ZIP files—converted entirely
+              in your browser.
             </p>
             <noscript>
               <p class="text-sm text-gray-600">JavaScript is required to use the converter.</p>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -355,7 +355,7 @@ function App() {
     } finally {
       setIsLoading(false);
     }
-  }, [currentProvider, getSelectedNodes, nodes, selectedPaths, excludedPaths, getDirectorySelectionState]);
+  }, [currentProvider, getSelectedNodes, nodes, selectedPaths, excludedPaths, showExcluded, getDirectorySelectionState]);
 
   return (
     <div className="min-h-screen flex flex-col bg-gray-50 dark:bg-gray-900">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,8 +18,24 @@ import {
   extractLocalName,
 } from '@/lib/utils/repoName';
 import { useStore } from '@/store';
-import type { FileNode, FileContent, ExtensionFilter as ExtensionFilterType, FormattedOutput } from '@/types';
+import type { FileNode, FileContent, ExtensionFilter as ExtensionFilterType, FormattedOutput, ProviderType } from '@/types';
 import type { IProvider } from '@/lib/providers/types';
+
+const TOKEN_STORAGE_KEYS: Partial<Record<ProviderType, string>> = {
+  github: 'github_token',
+  gitlab: 'gitlab_token',
+  azure: 'azure_token',
+};
+
+/**
+ * Tokens can be added or cleared after a repository is loaded, so the provider
+ * is given the stored token again before each round of requests
+ */
+function applyStoredCredentials(provider: IProvider, type: ProviderType) {
+  const storageKey = TOKEN_STORAGE_KEYS[type];
+  const token = storageKey ? sessionStorage.getItem(storageKey)?.trim() : undefined;
+  provider.setCredentials({ token: token || undefined });
+}
 
 function App() {
   const { setProviderType, setRepoUrl } = useStore();
@@ -156,11 +172,7 @@ function App() {
     setRepoName(extractGitHubRepoName(url));
 
     const provider = new GitHubProvider();
-    // Get GitHub token from sessionStorage if available
-    const token = sessionStorage.getItem('github_token');
-    if (token) {
-      provider.setCredentials({ token });
-    }
+    applyStoredCredentials(provider, 'github');
 
     await loadFiles(provider, url);
   }, [loadFiles, setProviderType, setRepoUrl]);
@@ -174,11 +186,7 @@ function App() {
     // Dynamically import GitLab provider (code splitting)
     const { GitLabProvider } = await import('@/features/gitlab/GitLabProvider');
     const provider = new GitLabProvider();
-    // Get GitLab token from sessionStorage if available
-    const token = sessionStorage.getItem('gitlab_token');
-    if (token) {
-      provider.setCredentials({ token });
-    }
+    applyStoredCredentials(provider, 'gitlab');
 
     await loadFiles(provider, url);
   }, [loadFiles, setProviderType, setRepoUrl]);
@@ -192,11 +200,7 @@ function App() {
     // Dynamically import Azure provider (code splitting)
     const { AzureDevOpsProvider } = await import('@/features/azure/AzureDevOpsProvider');
     const provider = new AzureDevOpsProvider();
-    // Get Azure token from sessionStorage if available
-    const token = sessionStorage.getItem('azure_token');
-    if (token) {
-      provider.setCredentials({ token });
-    }
+    applyStoredCredentials(provider, 'azure');
 
     await loadFiles(provider, url);
   }, [loadFiles, setProviderType, setRepoUrl]);
@@ -287,6 +291,7 @@ function App() {
 
     try {
       setIsLoading(true);
+      applyStoredCredentials(currentProvider, currentProvider.getType());
 
       // Get selected and non-excluded nodes from store
       const selectedNodes = getSelectedNodes();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,6 @@
 import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
+import { Button } from '@/components/ui/Button';
+import { Panel } from '@/components/ui/Panel';
 import { ThemeToggle } from '@/components/ui/ThemeToggle';
 import { ErrorDialog } from '@/components/ui/ErrorDialog';
 import { ProviderSelector } from '@/components/ProviderSelector';
@@ -270,6 +272,15 @@ function App() {
     return getGlobalSelectionState();
   }, [selectedPaths, nodes, getGlobalSelectionState]);
 
+  // Selection summary shown next to the generate action
+  const selectionSummary = useMemo(() => {
+    const selectable = nodes.filter(
+      (node) => node.type === 'blob' && !excludedPaths.has(node.path)
+    );
+    const selected = selectable.filter((node) => selectedPaths.has(node.path));
+    return { selected: selected.length, total: selectable.length };
+  }, [nodes, selectedPaths, excludedPaths]);
+
   // Handle generate output
   const handleGenerateOutput = useCallback(async () => {
     if (!currentProvider) return;
@@ -282,7 +293,8 @@ function App() {
 
       if (selectedNodes.length === 0) {
         setError({
-          message: 'No files selected.\n\nPlease select at least one file to generate output. You can:\n• Click the checkbox next to "File Tree" to select all files\n• Expand directories and select individual files\n• Use the Extension Filter to select files by type',
+          message:
+            'No files selected. Pick at least one file in the tree, or use the checkbox beside the Files heading to take everything.',
         });
         return;
       }
@@ -360,24 +372,22 @@ function App() {
   return (
     <div className="min-h-screen flex flex-col bg-gray-50 dark:bg-gray-900">
       {/* Header */}
-      <header className="sticky top-0 z-50 w-full border-b border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900">
-        <div className="container mx-auto flex h-14 sm:h-16 items-center justify-between px-3 sm:px-4 lg:px-6">
-          <div className="flex items-center gap-1.5 sm:gap-2 flex-wrap">
-            <div className="flex items-center gap-1.5 sm:gap-2">
-              <h1 className="text-lg sm:text-xl md:text-2xl font-bold text-gray-900 dark:text-gray-100">
-                repo2txt
-              </h1>
-              <span className="rounded-full bg-primary-100 dark:bg-primary-900 px-1.5 sm:px-2 py-0.5 text-[10px] sm:text-xs font-semibold text-primary-700 dark:text-primary-300">
-                v2.0 Beta
-              </span>
-            </div>
+      <header className="sticky top-0 z-50 w-full border-b border-gray-200 dark:border-gray-800 bg-white/95 backdrop-blur dark:bg-gray-900/95">
+        <div className="container mx-auto flex h-14 items-center justify-between px-3 sm:px-4 lg:px-6">
+          <div className="flex items-baseline gap-2 sm:gap-3">
+            <h1 className="text-base sm:text-lg font-semibold tracking-tight text-gray-900 dark:text-gray-100">
+              repo2txt
+            </h1>
+            <span className="rounded border border-gray-300 px-1.5 py-px text-[11px] font-medium text-gray-500 dark:border-gray-700 dark:text-gray-400">
+              v2.0 beta
+            </span>
             <a
               href="https://abinthomas.in/repo2txt-classic/"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-xs sm:text-sm text-gray-600 hover:text-primary-600 dark:text-gray-400 dark:hover:text-primary-400 transition-colors underline underline-offset-2"
+              className="hidden text-xs text-gray-500 transition-colors hover:text-primary-600 dark:text-gray-400 dark:hover:text-primary-400 sm:inline"
             >
-              Classic Version
+              Classic
             </a>
           </div>
 
@@ -405,21 +415,21 @@ function App() {
       <PaperPmfPromo />
 
       {/* Main Content */}
-      <main className="flex-1 container mx-auto px-3 sm:px-4 lg:px-6 py-4 sm:py-6 md:py-8">
-        <div className="max-w-7xl mx-auto space-y-4 sm:space-y-6 md:space-y-8">
+      <main className="container mx-auto flex-1 px-3 sm:px-4 lg:px-6">
+        <div className="mx-auto max-w-4xl pb-12 sm:pb-16">
           <section
-            className="mx-auto max-w-3xl space-y-2 text-center"
+            className="mx-auto max-w-2xl space-y-3 py-10 text-center sm:py-14"
             aria-labelledby="repo2txt-intro-heading"
           >
             <h2
               id="repo2txt-intro-heading"
-              className="text-xl sm:text-2xl md:text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-100"
+              className="text-2xl font-semibold tracking-tight text-gray-900 dark:text-gray-100 sm:text-3xl"
             >
               Convert repositories to plain text for LLMs
             </h2>
-            <p className="text-sm sm:text-base text-gray-600 dark:text-gray-400 text-balance">
-              Turn GitHub, GitLab, Azure DevOps, local folders, or ZIP files into clean, copy-ready
-              context for AI tools—entirely in your browser.
+            <p className="text-balance text-sm text-gray-600 dark:text-gray-400 sm:text-base">
+              GitHub, GitLab, Azure DevOps, local folders, and ZIP files—converted entirely in your
+              browser.
             </p>
           </section>
 
@@ -438,7 +448,7 @@ function App() {
 
           {/* Filters and File Tree */}
           {tree.length > 0 && (
-            <section className="space-y-6">
+            <section className="mt-4 space-y-4">
               {/* Advanced Filters - Collapsed by default */}
               <AdvancedFilters
                 extensions={extensionList}
@@ -453,56 +463,76 @@ function App() {
               />
 
               {/* File Tree */}
-              <div className="space-y-4" data-testid="file-tree-section">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-3">
-                    <label className="flex items-center gap-2 cursor-pointer">
-                      <input
-                        type="checkbox"
-                        checked={globalCheckboxState === 'checked'}
-                        ref={(input) => {
-                          if (input) {
-                            input.indeterminate = globalCheckboxState === 'indeterminate';
-                          }
-                        }}
-                        onChange={handleGlobalToggle}
-                        className="rounded border-gray-300 text-primary-600 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800"
-                        aria-label="Select all files"
-                      />
-                      <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100" data-testid="file-tree-heading">
-                        File Tree
-                      </h2>
-                    </label>
-                  </div>
-                  <button
-                    onClick={handleGenerateOutput}
-                    disabled={isLoading}
-                    data-testid="generate-output-button"
-                    className="inline-flex items-center justify-center rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-primary-600 text-white hover:bg-primary-700 dark:bg-primary-500 dark:hover:bg-primary-600 h-11 sm:h-10 px-4 sm:px-6 text-sm min-w-[44px] touch-manipulation"
-                  >
-                    <svg className="w-4 h-4 sm:mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
-                    </svg>
-                    <span className="hidden sm:inline">Generate Output</span>
-                  </button>
+              <Panel data-testid="file-tree-section" className="overflow-hidden">
+                <div className="flex items-center justify-between gap-3 px-3 py-2.5">
+                  <label className="flex cursor-pointer items-center gap-2.5">
+                    <input
+                      type="checkbox"
+                      checked={globalCheckboxState === 'checked'}
+                      ref={(input) => {
+                        if (input) {
+                          input.indeterminate = globalCheckboxState === 'indeterminate';
+                        }
+                      }}
+                      onChange={handleGlobalToggle}
+                      className="h-4 w-4 cursor-pointer rounded accent-primary-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+                      aria-label="Select all files"
+                    />
+                    <h2
+                      className="text-sm font-semibold text-gray-900 dark:text-gray-100"
+                      data-testid="file-tree-heading"
+                    >
+                      Files
+                    </h2>
+                  </label>
+                  <span className="truncate font-mono text-xs text-gray-500 dark:text-gray-400">
+                    {repoName}
+                  </span>
                 </div>
 
-                <FileTree
-                  nodes={tree}
-                  onToggle={toggleExpanded}
-                  onSelect={toggleSelection}
-                  showExcluded={showExcluded}
-                />
-              </div>
+                <div className="border-y border-gray-200 dark:border-gray-800">
+                  <FileTree
+                    nodes={tree}
+                    onToggle={toggleExpanded}
+                    onSelect={toggleSelection}
+                    showExcluded={showExcluded}
+                  />
+                </div>
+
+                <div className="flex items-center justify-between gap-3 px-3 py-2.5">
+                  <p className="text-xs tabular-nums text-gray-500 dark:text-gray-400">
+                    <span className="font-medium text-gray-900 dark:text-gray-100">
+                      {selectionSummary.selected.toLocaleString()}
+                    </span>{' '}
+                    of {selectionSummary.total.toLocaleString()} files selected
+                  </p>
+                  <Button
+                    onClick={handleGenerateOutput}
+                    disabled={isLoading}
+                    size="sm"
+                    data-testid="generate-output-button"
+                  >
+                    Generate Output
+                  </Button>
+                </div>
+              </Panel>
             </section>
           )}
 
+          {/* Busy state for the first load, before there is a tree to sit under */}
+          {isLoading && tree.length === 0 && (
+            <Panel
+              role="status"
+              className="mt-4 flex items-center justify-center gap-3 py-8 text-sm text-gray-500 dark:text-gray-400"
+            >
+              <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-primary-600 dark:border-gray-700 dark:border-t-primary-400" />
+              Loading repository
+            </Panel>
+          )}
+
           {/* Output */}
-          {(output || isLoading) && (
-            <section ref={outputRef}>
-              <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
-                Output
-              </h2>
+          {(output || (isLoading && tree.length > 0)) && (
+            <section ref={outputRef} className="mt-4 scroll-mt-20">
               <OutputPanel output={output} isLoading={isLoading} repoName={repoName} />
             </section>
           )}
@@ -510,29 +540,27 @@ function App() {
       </main>
 
       {/* Footer */}
-      <footer className="border-t border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 py-4 sm:py-6">
-        <div className="container mx-auto px-3 sm:px-4 lg:px-6 text-center text-xs sm:text-sm text-gray-600 dark:text-gray-400">
+      <footer className="border-t border-gray-200 bg-white py-5 dark:border-gray-800 dark:bg-gray-900">
+        <div className="container mx-auto flex flex-col items-center gap-1 px-3 text-xs text-gray-500 dark:text-gray-400 sm:flex-row sm:justify-between sm:px-4 lg:px-6">
           <p>
-            Built with ❤️ by{' '}
+            Built by{' '}
             <a
               href="https://github.com/abinthomasonline"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-primary-600 dark:text-primary-400 hover:underline"
+              className="text-gray-700 underline underline-offset-2 transition-colors hover:text-primary-600 dark:text-gray-300 dark:hover:text-primary-400"
             >
               abinthomasonline
             </a>
           </p>
-          <p className="mt-2">
-            Open source under MIT License • Privacy-focused • Browser-only
-          </p>
+          <p>MIT licensed · Browser-only</p>
         </div>
       </footer>
 
       {/* Error Dialog */}
       {error && (
         <ErrorDialog
-          title="Unable to Complete Request"
+          title="Unable to complete request"
           message={error.message}
           onClose={() => setError(null)}
           onAction={error.recovery}

--- a/src/components/AdvancedFilters.tsx
+++ b/src/components/AdvancedFilters.tsx
@@ -6,6 +6,7 @@
 import { useState } from 'react';
 import { ExtensionFilter } from './filters/ExtensionFilter';
 import { GitIgnoreEditor } from './filters/GitIgnoreEditor';
+import { Panel } from './ui/Panel';
 import type { ExtensionFilter as ExtensionFilterType } from '@/types';
 
 interface AdvancedFiltersProps {
@@ -37,70 +38,61 @@ export function AdvancedFilters({
   const [isExpanded, setIsExpanded] = useState(false);
 
   return (
-    <div className="rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900">
+    <Panel className="overflow-hidden">
       {/* Header */}
       <button
         onClick={() => setIsExpanded(!isExpanded)}
-        className="w-full flex items-center justify-between p-3 sm:p-4 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors min-h-[44px] touch-manipulation"
+        aria-expanded={isExpanded}
+        className="flex w-full items-center justify-between gap-3 px-3 py-2.5 text-left transition-colors hover:bg-gray-50 dark:hover:bg-gray-800/60"
       >
-        <div className="flex items-center gap-1.5 sm:gap-2">
-          <h3 className="text-base sm:text-lg font-semibold text-gray-900 dark:text-gray-100">
-            Advanced Filters
-          </h3>
-          <span className="text-[10px] sm:text-xs text-gray-500 dark:text-gray-400">
-            Extension & Gitignore
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Filters</h3>
+        <div className="flex items-center gap-3">
+          <span className="tabular-nums text-xs text-gray-500 dark:text-gray-400">
+            {extensions.length} types · {gitignorePatterns.length} patterns
           </span>
-        </div>
-        <svg
-          className={`w-5 h-5 text-gray-500 dark:text-gray-400 transition-transform ${
-            isExpanded ? 'rotate-180' : ''
-          }`}
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
+          <svg
+            className={`h-4 w-4 text-gray-400 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+            fill="none"
+            stroke="currentColor"
             strokeWidth={2}
-            d="M19 9l-7 7-7-7"
-          />
-        </svg>
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+          </svg>
+        </div>
       </button>
 
       {/* Content */}
       {isExpanded && (
-        <div className="p-3 sm:p-4 border-t border-gray-200 dark:border-gray-700">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6">
-            {/* Extension Filter */}
-            <div className="space-y-3">
-              <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100">
-                File Extensions
-              </h4>
-              <ExtensionFilter
-                extensions={extensions}
-                onToggle={onExtensionToggle}
-                onSelectAll={onSelectAllExtensions}
-                onDeselectAll={onDeselectAllExtensions}
-              />
-            </div>
+        <div className="grid grid-cols-1 divide-y divide-gray-200 border-t border-gray-200 dark:divide-gray-800 dark:border-gray-800 lg:grid-cols-2 lg:divide-x lg:divide-y-0">
+          {/* Extension Filter */}
+          <div className="space-y-3 p-3 sm:p-4">
+            <h4 className="text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+              Extensions
+            </h4>
+            <ExtensionFilter
+              extensions={extensions}
+              onToggle={onExtensionToggle}
+              onSelectAll={onSelectAllExtensions}
+              onDeselectAll={onDeselectAllExtensions}
+            />
+          </div>
 
-            {/* Gitignore Patterns */}
-            <div className="space-y-3">
-              <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100">
-                Gitignore Patterns
-              </h4>
-              <GitIgnoreEditor
-                patterns={gitignorePatterns}
-                onApply={onApplyGitignore}
-                onReset={onResetGitignore}
-                showExcluded={showExcluded}
-                onToggleExcluded={onToggleExcluded}
-              />
-            </div>
+          {/* Gitignore Patterns */}
+          <div className="space-y-3 p-3 sm:p-4">
+            <h4 className="text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+              Ignore patterns
+            </h4>
+            <GitIgnoreEditor
+              patterns={gitignorePatterns}
+              onApply={onApplyGitignore}
+              onReset={onResetGitignore}
+              showExcluded={showExcluded}
+              onToggleExcluded={onToggleExcluded}
+            />
           </div>
         </div>
       )}
-    </div>
+    </Panel>
   );
 }

--- a/src/components/FileStats.tsx
+++ b/src/components/FileStats.tsx
@@ -29,92 +29,48 @@ export function FileStats({ files }: FileStatsProps) {
     (a, b) => (b.tokenCount || 0) - (a.tokenCount || 0)
   );
 
-  const totalTokens = sortedFiles.reduce((sum, f) => sum + (f.tokenCount || 0), 0);
-  const totalLines = sortedFiles.reduce((sum, f) => sum + (f.lineCount || 0), 0);
-
   return (
-    <div className="rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900">
-      {/* Header with summary - Always visible */}
+    <div className="border-t border-gray-200 dark:border-gray-800">
       <button
         onClick={() => setIsExpanded(!isExpanded)}
-        className="w-full p-4 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+        aria-expanded={isExpanded}
+        className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left transition-colors hover:bg-gray-50 dark:hover:bg-gray-800/60"
       >
-        <div className="flex items-center justify-between mb-3">
-          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-            File Statistics
-          </h3>
-          <svg
-            className={`w-5 h-5 text-gray-500 transition-transform ${
-              isExpanded ? 'transform rotate-180' : ''
-            }`}
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M19 9l-7 7-7-7"
-            />
-          </svg>
-        </div>
-
-        {/* Summary - Always visible */}
-        <div className="grid grid-cols-3 gap-4">
-          <div>
-            <div className="text-xs text-gray-500 dark:text-gray-400">Files</div>
-            <div className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-              {sortedFiles.length}
-            </div>
-          </div>
-          <div>
-            <div className="text-xs text-gray-500 dark:text-gray-400">Total Lines</div>
-            <div className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-              {totalLines.toLocaleString()}
-            </div>
-          </div>
-          <div>
-            <div className="text-xs text-gray-500 dark:text-gray-400">Total Tokens</div>
-            <div className="text-lg font-semibold text-primary-600 dark:text-primary-400">
-              {totalTokens.toLocaleString()}
-            </div>
-          </div>
-        </div>
+        <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+          Largest files
+        </span>
+        <svg
+          className={`h-4 w-4 text-gray-400 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+        </svg>
       </button>
 
-      {/* Collapsible per-file details */}
       {isExpanded && (
-        <div className="px-4 pb-4 border-t border-gray-200 dark:border-gray-700">
-
-          {/* Per-file list */}
-          <div className="space-y-1 max-h-64 overflow-y-auto mt-4">
-            {sortedFiles.map((file) => (
-              <div
-                key={file.path}
-                className="flex items-center justify-between py-2 px-3 rounded hover:bg-gray-50 dark:hover:bg-gray-800"
+        <div className="max-h-64 overflow-y-auto border-t border-gray-100 dark:border-gray-800/60">
+          {sortedFiles.map((file) => (
+            <div
+              key={file.path}
+              className="flex items-center justify-between gap-4 px-3 py-1.5 text-xs hover:bg-gray-50 dark:hover:bg-gray-800/60"
+            >
+              <span
+                className="truncate font-mono text-gray-700 dark:text-gray-300"
+                title={file.path}
               >
-                <div className="flex-1 min-w-0 mr-4">
-                  <div className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
-                    {file.path.split('/').pop()}
-                  </div>
-                  <div className="text-xs text-gray-500 dark:text-gray-400 truncate">
-                    {file.path}
-                  </div>
-                </div>
-                <div className="flex gap-4 text-sm">
-                  <div className="text-gray-600 dark:text-gray-400">
-                    <span className="font-medium">{file.lineCount?.toLocaleString()}</span>
-                    <span className="text-xs ml-1">lines</span>
-                  </div>
-                  <div className="text-primary-600 dark:text-primary-400">
-                    <span className="font-medium">{file.tokenCount?.toLocaleString()}</span>
-                    <span className="text-xs ml-1">tokens</span>
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
+                {file.path}
+              </span>
+              <span className="flex-shrink-0 tabular-nums text-gray-500 dark:text-gray-400">
+                <span className="font-medium text-gray-700 dark:text-gray-300">
+                  {file.tokenCount?.toLocaleString()}
+                </span>{' '}
+                tokens · {file.lineCount?.toLocaleString() ?? '—'} lines
+              </span>
+            </div>
+          ))}
         </div>
       )}
     </div>

--- a/src/components/OutputPanel.tsx
+++ b/src/components/OutputPanel.tsx
@@ -5,6 +5,7 @@
 
 import { useState } from 'react';
 import { Button } from './ui/Button';
+import { Panel } from './ui/Panel';
 import { FileStats } from './FileStats';
 import type { FormattedOutput } from '@/types';
 
@@ -92,154 +93,76 @@ export function OutputPanel({ output, isLoading = false, repoName = 'repo-export
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-64 border border-gray-300 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-900">
-        <div className="text-center">
-          <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
-          <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
-            Loading files...
-          </p>
-        </div>
-      </div>
+      <Panel className="flex h-40 items-center justify-center gap-3 text-sm text-gray-500 dark:text-gray-400">
+        <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-primary-600 dark:border-gray-700 dark:border-t-primary-400" />
+        Reading files
+      </Panel>
     );
   }
 
   if (!output) {
     return (
-      <div className="flex items-center justify-center h-64 border border-gray-300 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-900">
-        <div className="text-center text-gray-500 dark:text-gray-400">
-          <svg
-            className="mx-auto h-12 w-12 text-gray-400"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-            />
-          </svg>
-          <p className="mt-2 text-sm">Select files to generate output</p>
-        </div>
-      </div>
+      <Panel className="flex h-40 items-center justify-center text-sm text-gray-500 dark:text-gray-400">
+        Select files to generate output
+      </Panel>
     );
   }
 
   const fullText = `${output.directoryTree}\n\n${output.fileContents}`;
+  const fileCount = output.files?.length ?? 0;
 
   return (
-    <div className="space-y-3 sm:space-y-4">
-      {/* Stats */}
-      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between p-3 sm:p-4 rounded-lg border border-gray-300 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 gap-3 sm:gap-0">
-        <div className="flex gap-4 sm:gap-6">
-          <div>
-            <p className="text-xs text-gray-500 dark:text-gray-400">Lines</p>
-            <p className="text-base sm:text-lg font-semibold text-gray-900 dark:text-gray-100">
-              {output.lineCount.toLocaleString()}
-            </p>
-          </div>
-          <div>
-            <p className="text-xs text-gray-500 dark:text-gray-400">Tokens</p>
-            <p className="text-base sm:text-lg font-semibold text-gray-900 dark:text-gray-100">
+    <Panel className="overflow-hidden">
+      {/* Totals and actions */}
+      <div className="flex flex-col gap-3 px-3 py-2.5 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-baseline gap-2">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Output</h2>
+          <p className="tabular-nums text-xs text-gray-500 dark:text-gray-400">
+            {fileCount.toLocaleString()} files · {output.lineCount.toLocaleString()} lines ·{' '}
+            <span className="font-medium text-gray-900 dark:text-gray-100">
               {output.tokenCount.toLocaleString()}
-            </p>
-          </div>
+            </span>{' '}
+            tokens
+          </p>
         </div>
 
-        <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={handleCopy}
-            title="Copy to clipboard"
-          >
-            {copied ? (
-              <>
-                <svg className="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 20 20">
-                  <path
-                    fillRule="evenodd"
-                    d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                    clipRule="evenodd"
-                  />
-                </svg>
-                Copied!
-              </>
-            ) : (
-              <>
-                <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
-                  />
-                </svg>
-                Copy
-              </>
-            )}
+        <div className="flex items-center gap-2">
+          <Button variant="secondary" size="sm" onClick={handleCopy} title="Copy to clipboard">
+            {copied ? 'Copied' : 'Copy'}
           </Button>
 
-          <div className="flex gap-2">
-            <select
-              value={downloadFormat}
-              onChange={(e) => setDownloadFormat(e.target.value as 'txt' | 'md' | 'zip')}
-              className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1.5 text-sm text-gray-900 dark:text-gray-100 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:focus:ring-primary-400"
-              title="Select download format"
-            >
-              <option value="txt">TXT</option>
-              <option value="md">MD</option>
-              <option value="zip">ZIP</option>
-            </select>
+          <select
+            value={downloadFormat}
+            onChange={(e) => setDownloadFormat(e.target.value as 'txt' | 'md' | 'zip')}
+            className="h-9 rounded-md border border-gray-200 bg-white px-2 text-sm text-gray-700 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300 sm:h-8"
+            aria-label="Download format"
+          >
+            <option value="txt">.txt</option>
+            <option value="md">.md</option>
+            <option value="zip">.zip</option>
+          </select>
 
-            <Button
-              variant="primary"
-              size="sm"
-              onClick={handleDownload}
-              disabled={isDownloading}
-              title={`Download as ${downloadFormat.toUpperCase()}`}
-            >
-              {isDownloading ? (
-                <>
-                  <div className="w-4 h-4 mr-1 border-2 border-white border-t-transparent rounded-full animate-spin" />
-                  Downloading...
-                </>
-              ) : (
-                <>
-                  <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
-                    />
-                  </svg>
-                  Download
-                </>
-              )}
-            </Button>
-          </div>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={handleDownload}
+            disabled={isDownloading}
+            title={`Download as ${downloadFormat.toUpperCase()}`}
+          >
+            {isDownloading ? 'Preparing' : 'Download'}
+          </Button>
         </div>
       </div>
 
-      {/* Per-file statistics */}
-      {output.files && output.files.length > 0 && (
-        <FileStats files={output.files} />
-      )}
+      {/* Per-file breakdown */}
+      {output.files && output.files.length > 0 && <FileStats files={output.files} />}
 
       {/* Output preview */}
-      <div className="rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900">
-        <div className="p-4 border-b border-gray-300 dark:border-gray-700">
-          <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100">
-            Output Preview
-          </h3>
-        </div>
-        <div className="p-4 max-h-96 overflow-auto">
-          <pre className="text-xs font-mono text-gray-800 dark:text-gray-200 whitespace-pre-wrap">
-            {fullText}
-          </pre>
-        </div>
+      <div className="max-h-96 overflow-auto border-t border-gray-200 bg-gray-50 p-3 dark:border-gray-800 dark:bg-gray-950/50">
+        <pre className="whitespace-pre-wrap font-mono text-xs leading-relaxed text-gray-700 dark:text-gray-300">
+          {fullText}
+        </pre>
       </div>
-    </div>
+    </Panel>
   );
 }

--- a/src/components/ProviderSelector.tsx
+++ b/src/components/ProviderSelector.tsx
@@ -5,6 +5,7 @@
 
 import { lazy, Suspense, useState } from 'react';
 import { GitHubForm } from '@/features/github/components/GitHubForm';
+import { Panel } from '@/components/ui/Panel';
 import type { ProviderType } from '@/types';
 
 const LocalForm = lazy(() =>
@@ -22,6 +23,56 @@ const AzureForm = lazy(() =>
     default: module.AzureForm,
   }))
 );
+
+const PROVIDERS: Array<{
+  id: ProviderType;
+  label: string;
+  beta?: boolean;
+  icon: React.ReactNode;
+}> = [
+  {
+    id: 'github',
+    label: 'GitHub',
+    icon: (
+      <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+      </svg>
+    ),
+  },
+  {
+    id: 'local',
+    label: 'Local',
+    icon: (
+      <svg className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"
+        />
+      </svg>
+    ),
+  },
+  {
+    id: 'gitlab',
+    label: 'GitLab',
+    beta: true,
+    icon: (
+      <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+        <path d="M23.6 9.593l-.033-.086L20.3.98a.851.851 0 00-.336-.405.875.875 0 00-1.056.095c-.139.127-.24.296-.289.485l-2.224 6.827H7.617L5.393 1.165a.857.857 0 00-.29-.485.875.875 0 00-1.055-.095.857.857 0 00-.336.405L.443 9.502l-.032.086a6.066 6.066 0 002.012 7.01l.01.008.03.022 4.977 3.727 2.462 1.862 1.5 1.132a1.008 1.008 0 001.22 0l1.499-1.132 2.461-1.862 5.006-3.75.01-.008a6.068 6.068 0 002.012-7.004z" />
+      </svg>
+    ),
+  },
+  {
+    id: 'azure',
+    label: 'Azure',
+    beta: true,
+    icon: (
+      <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+        <path d="M11.19 14.23l-3.47-1.85v-2.7l7.95-4.24v2.27l-5.94 3.17v.94l5.94 3.17v2.27l-7.95-4.24 3.47 1.85zm1.62 0l3.47-1.85v-2.7l-7.95-4.24v2.27l5.94 3.17v.94l-5.94 3.17v2.27l7.95-4.24-3.47 1.85z" />
+      </svg>
+    ),
+  },
+];
 
 function ProviderFormFallback() {
   return (
@@ -63,103 +114,55 @@ export function ProviderSelector({
   };
 
   return (
-    <div className="space-y-3 sm:space-y-4">
+    <div className="space-y-3">
       {/* Provider tabs */}
-      <div className="flex space-x-1 rounded-lg bg-gray-100 dark:bg-gray-800 p-1">
-        <button
-          onClick={() => handleProviderChange('github')}
-          disabled={disabled}
-          data-testid="provider-tab-github"
-          className={`
-            flex-1 flex items-center justify-center gap-1.5 sm:gap-2 rounded-md px-3 sm:px-4 py-3 sm:py-2.5 text-sm font-medium transition-colors min-h-[44px] touch-manipulation
-            ${
-              activeProvider === 'github'
-                ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow'
-                : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100'
-            }
-            ${disabled ? 'opacity-50 cursor-not-allowed' : ''}
-          `}
-        >
-          <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-            <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-          </svg>
-          GitHub
-        </button>
+      <div
+        role="tablist"
+        aria-label="Source"
+        className="grid grid-cols-2 gap-1 rounded-lg bg-gray-100 p-1 dark:bg-gray-800/70 sm:flex"
+      >
+        {PROVIDERS.map((provider) => {
+          const isActive = activeProvider === provider.id;
 
-        <button
-          onClick={() => handleProviderChange('local')}
-          disabled={disabled}
-          data-testid="provider-tab-local"
-          className={`
-            flex-1 flex items-center justify-center gap-1.5 sm:gap-2 rounded-md px-3 sm:px-4 py-3 sm:py-2.5 text-sm font-medium transition-colors min-h-[44px] touch-manipulation
-            ${
-              activeProvider === 'local'
-                ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow'
-                : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100'
-            }
-            ${disabled ? 'opacity-50 cursor-not-allowed' : ''}
-          `}
-        >
-          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"
-            />
-          </svg>
-          Local
-        </button>
-
-        <button
-          onClick={() => handleProviderChange('gitlab')}
-          disabled={disabled}
-          data-testid="provider-tab-gitlab"
-          className={`
-            flex-1 flex flex-col items-center justify-center gap-0.5 rounded-md px-3 sm:px-4 py-2.5 sm:py-2.5 text-sm font-medium transition-colors min-h-[44px] touch-manipulation
-            ${
-              activeProvider === 'gitlab'
-                ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow'
-                : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100'
-            }
-            ${disabled ? 'opacity-50 cursor-not-allowed' : ''}
-          `}
-        >
-          <div className="flex items-center gap-2">
-            <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-              <path d="M23.6 9.593l-.033-.086L20.3.98a.851.851 0 00-.336-.405.875.875 0 00-1.056.095c-.139.127-.24.296-.289.485l-2.224 6.827H7.617L5.393 1.165a.857.857 0 00-.29-.485.875.875 0 00-1.055-.095.857.857 0 00-.336.405L.443 9.502l-.032.086a6.066 6.066 0 002.012 7.01l.01.008.03.022 4.977 3.727 2.462 1.862 1.5 1.132a1.008 1.008 0 001.22 0l1.499-1.132 2.461-1.862 5.006-3.75.01-.008a6.068 6.068 0 002.012-7.004z" />
-            </svg>
-            <span>GitLab</span>
-          </div>
-          <span className="text-[10px] font-semibold text-orange-600 dark:text-orange-400">BETA</span>
-        </button>
-
-        <button
-          onClick={() => handleProviderChange('azure')}
-          disabled={disabled}
-          data-testid="provider-tab-azure"
-          className={`
-            flex-1 flex flex-col items-center justify-center gap-0.5 rounded-md px-3 sm:px-4 py-2.5 sm:py-2.5 text-sm font-medium transition-colors min-h-[44px] touch-manipulation
-            ${
-              activeProvider === 'azure'
-                ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow'
-                : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100'
-            }
-            ${disabled ? 'opacity-50 cursor-not-allowed' : ''}
-          `}
-        >
-          <div className="flex items-center gap-1.5 sm:gap-2">
-            <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-              <path d="M11.19 14.23l-3.47-1.85v-2.7l7.95-4.24v2.27l-5.94 3.17v.94l5.94 3.17v2.27l-7.95-4.24 3.47 1.85zm1.62 0l3.47-1.85v-2.7l-7.95-4.24v2.27l5.94 3.17v.94l-5.94 3.17v2.27l7.95-4.24-3.47 1.85z" />
-            </svg>
-            <span>Azure</span>
-          </div>
-          <span className="text-[10px] font-semibold text-orange-600 dark:text-orange-400">BETA</span>
-        </button>
+          return (
+            <button
+              key={provider.id}
+              role="tab"
+              id={`provider-tab-${provider.id}`}
+              aria-selected={isActive}
+              aria-controls="provider-panel"
+              onClick={() => handleProviderChange(provider.id)}
+              disabled={disabled}
+              data-testid={`provider-tab-${provider.id}`}
+              className={`
+                flex min-h-[40px] flex-1 touch-manipulation items-center justify-center gap-2 rounded-md px-2 text-sm font-medium transition-colors sm:px-4
+                ${
+                  isActive
+                    ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-gray-100'
+                    : 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100'
+                }
+                ${disabled ? 'cursor-not-allowed opacity-50' : ''}
+              `}
+            >
+              {provider.icon}
+              <span>{provider.label}</span>
+              {provider.beta && (
+                <span className="text-[10px] font-semibold uppercase tracking-wide text-amber-600 dark:text-amber-500">
+                  beta
+                </span>
+              )}
+            </button>
+          );
+        })}
       </div>
 
       {/* Provider form */}
-      <div className="rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 p-4 sm:p-6">
+      <Panel
+        id="provider-panel"
+        role="tabpanel"
+        aria-labelledby={`provider-tab-${activeProvider}`}
+        className="p-4 sm:p-5"
+      >
         <Suspense fallback={<ProviderFormFallback />}>
           {activeProvider === 'github' ? (
             <GitHubForm onSubmit={onGitHubSubmit} disabled={disabled} />
@@ -176,7 +179,7 @@ export function ProviderSelector({
             <AzureForm onSubmit={onAzureSubmit} disabled={disabled} />
           )}
         </Suspense>
-      </div>
+      </Panel>
     </div>
   );
 }

--- a/src/components/__tests__/FileStats.test.tsx
+++ b/src/components/__tests__/FileStats.test.tsx
@@ -26,15 +26,10 @@ describe('FileStats', () => {
     },
   ];
 
-  it('should render file statistics with summary always visible', () => {
+  it('should render collapsed with per-file details hidden', () => {
     render(<FileStats files={mockFiles} />);
 
-    expect(screen.getByText('File Statistics')).toBeInTheDocument();
-
-    // Summary stats should be visible even when collapsed
-    expect(screen.getByText('3')).toBeInTheDocument(); // File count
-    expect(screen.getByText('175')).toBeInTheDocument(); // Total lines
-    expect(screen.getByText('525')).toBeInTheDocument(); // Total tokens
+    expect(screen.getByText('Largest files')).toBeInTheDocument();
 
     // But per-file details should be hidden
     expect(screen.queryByText('src/App.tsx')).not.toBeInTheDocument();
@@ -46,8 +41,8 @@ describe('FileStats', () => {
     // Per-file details should be hidden initially
     expect(screen.queryByText('src/App.tsx')).not.toBeInTheDocument();
 
-    const header = screen.getByText('File Statistics');
-    await userEvent.click(header);
+    // Expand the component
+    await userEvent.click(screen.getByText('Largest files'));
 
     // Should now show per-file details
     expect(screen.getByText('src/App.tsx')).toBeInTheDocument();
@@ -56,38 +51,28 @@ describe('FileStats', () => {
   });
 
   it('should render files sorted by token count when expanded', async () => {
-    render(<FileStats files={mockFiles} />);
+    const { container } = render(<FileStats files={mockFiles} />);
 
     // Expand the component
-    const header = screen.getByText('File Statistics');
-    await userEvent.click(header);
+    await userEvent.click(screen.getByText('Largest files'));
 
     // Check that App.tsx (300 tokens) appears before index.ts (150 tokens)
-    const appElement = screen.getByText('src/App.tsx');
-    const indexElement = screen.getByText('src/index.ts');
-    const utilsElement = screen.getByText('src/utils.ts');
-
-    expect(appElement).toBeInTheDocument();
-    expect(indexElement).toBeInTheDocument();
-    expect(utilsElement).toBeInTheDocument();
-
-    // Verify the sorting by checking token counts are in descending order
-    expect(screen.getByText('300')).toBeInTheDocument(); // App.tsx
-    expect(screen.getByText('150')).toBeInTheDocument(); // index.ts
-    expect(screen.getByText('75')).toBeInTheDocument(); // utils.ts
+    const paths = Array.from(container.querySelectorAll('[title]')).map((el) => el.textContent);
+    expect(paths).toEqual(['src/App.tsx', 'src/index.ts', 'src/utils.ts']);
   });
 
-  it('should display per-file statistics when expanded', async () => {
+  it('should display per-file token and line counts when expanded', async () => {
     render(<FileStats files={mockFiles} />);
 
     // Expand the component
-    const header = screen.getByText('File Statistics');
-    await userEvent.click(header);
+    await userEvent.click(screen.getByText('Largest files'));
 
-    expect(screen.getByText('50')).toBeInTheDocument(); // index.ts lines
-    expect(screen.getByText('150')).toBeInTheDocument(); // index.ts tokens
-    expect(screen.getByText('100')).toBeInTheDocument(); // App.tsx lines
-    expect(screen.getByText('300')).toBeInTheDocument(); // App.tsx tokens
+    expect(screen.getByTitle('src/App.tsx').parentElement?.textContent).toContain(
+      '300 tokens · 100 lines'
+    );
+    expect(screen.getByTitle('src/index.ts').parentElement?.textContent).toContain(
+      '150 tokens · 50 lines'
+    );
   });
 
   it('should not render when no files', () => {
@@ -119,12 +104,12 @@ describe('FileStats', () => {
 
     render(<FileStats files={files} />);
 
-    expect(screen.getByText('File Statistics')).toBeInTheDocument();
-
     // Expand to verify it handles missing lineCount gracefully
-    const header = screen.getByText('File Statistics');
-    await userEvent.click(header);
+    await userEvent.click(screen.getByText('Largest files'));
 
     expect(screen.getByText('src/index.ts')).toBeInTheDocument();
+    expect(screen.getByTitle('src/index.ts').parentElement?.textContent).toContain(
+      '100 tokens · — lines'
+    );
   });
 });

--- a/src/components/file-tree/FileTree.tsx
+++ b/src/components/file-tree/FileTree.tsx
@@ -8,6 +8,8 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import { FileTreeNode } from './FileTreeNode';
 import type { TreeNode } from '@/types';
 
+const ROW_HEIGHT = 28;
+
 interface FileTreeProps {
   nodes: TreeNode[];
   onToggle?: (path: string) => void;
@@ -64,29 +66,17 @@ export function FileTree({
   const virtualizer = useVirtualizer({
     count: flatNodes.length,
     getScrollElement: () => parentRef.current,
-    estimateSize: () => 32, // Estimated row height
+    estimateSize: () => ROW_HEIGHT,
     overscan: 10, // Number of items to render outside visible area
   });
 
   if (nodes.length === 0) {
     return (
-      <div className="flex items-center justify-center h-48 text-gray-500 dark:text-gray-400">
-        <div className="text-center">
-          <svg
-            className="mx-auto h-12 w-12 text-gray-400"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"
-            />
-          </svg>
-          <p className="mt-2 text-sm">No files to display</p>
-        </div>
+      <div
+        data-testid="file-tree"
+        className="flex h-40 items-center justify-center text-sm text-gray-500 dark:text-gray-400"
+      >
+        <p>No files to display</p>
       </div>
     );
   }
@@ -95,7 +85,7 @@ export function FileTree({
     <div
       ref={parentRef}
       data-testid="file-tree"
-      className="border border-gray-300 dark:border-gray-700 rounded-lg overflow-auto bg-white dark:bg-gray-900"
+      className="overflow-auto py-1"
       style={{ maxHeight: `${maxHeight}px` }}
     >
       <div

--- a/src/components/file-tree/FileTreeNode.tsx
+++ b/src/components/file-tree/FileTreeNode.tsx
@@ -22,6 +22,7 @@ export function FileTreeNode({
   showExcluded = false,
 }: FileTreeNodeProps) {
   const isDirectory = node.type === 'directory';
+  const isExpanded = isDirectory && node.children !== undefined;
   const isExcluded = node.excluded || false;
   const isVisible = node.visible !== false;
 
@@ -34,10 +35,17 @@ export function FileTreeNode({
   );
 
   const handleToggle = useCallback(() => {
+    onToggle?.(node.path);
+  }, [node.path, onToggle]);
+
+  // Clicking a row expands a directory or flips a file's selection
+  const handleRowClick = useCallback(() => {
     if (isDirectory) {
-      onToggle?.(node.path);
+      handleToggle();
+    } else if (!isExcluded) {
+      onSelect?.(node.path, node.selected !== true);
     }
-  }, [isDirectory, node.path, onToggle]);
+  }, [handleToggle, isDirectory, isExcluded, node.path, node.selected, onSelect]);
 
   // Don't render if not visible and showExcluded is false
   if (!isVisible && !showExcluded) {
@@ -46,16 +54,21 @@ export function FileTreeNode({
 
   const getFileIcon = () => {
     if (isDirectory) {
-      return (
-        <svg className="w-4 h-4 text-blue-500" fill="currentColor" viewBox="0 0 20 20">
-          <path d="M2 6a2 2 0 012-2h5l2 2h5a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6z" />
+      return isExpanded ? (
+        <svg className="w-4 h-4 text-gray-400 dark:text-gray-500" fill="currentColor" viewBox="0 0 20 20">
+          <path d="M2 6a2 2 0 012-2h4l2 2h4a2 2 0 012 2H4a2 2 0 00-1.94 1.515L2 9.5V6z" />
+          <path d="M4.06 9h13.38a1 1 0 01.97 1.243l-1.25 5A1 1 0 0116.19 16H2.75a1 1 0 01-.97-1.243l1.31-5.243A1 1 0 014.06 9z" />
+        </svg>
+      ) : (
+        <svg className="w-4 h-4 text-gray-400 dark:text-gray-500" fill="currentColor" viewBox="0 0 20 20">
+          <path d="M2 6a2 2 0 012-2h4l2 2h4a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6z" />
         </svg>
       );
     }
 
     // File icon - can be enhanced with extension-specific icons later
     return (
-      <svg className="w-4 h-4 text-gray-500" fill="currentColor" viewBox="0 0 20 20">
+      <svg className="w-4 h-4 text-gray-400 dark:text-gray-600" fill="currentColor" viewBox="0 0 20 20">
         <path
           fillRule="evenodd"
           d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z"
@@ -76,41 +89,53 @@ export function FileTreeNode({
   return (
     <div
       className={`
-        flex items-center gap-2 py-1 px-2 hover:bg-gray-100 dark:hover:bg-gray-800 rounded
+        group flex h-full items-center gap-2 pl-2 pr-3 text-sm
+        hover:bg-gray-100 dark:hover:bg-gray-800/70
         ${isExcluded ? 'opacity-50' : ''}
-        ${isDirectory ? 'cursor-pointer' : ''}
+        ${isDirectory || !isExcluded ? 'cursor-pointer' : ''}
       `}
-      style={{ paddingLeft: `${depth * 20 + 8}px` }}
-      onClick={handleToggle}
+      onClick={handleRowClick}
     >
-      {/* Expand/collapse icon for directories */}
-      {isDirectory && (
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            handleToggle();
-          }}
-          className="flex-shrink-0 p-0.5 hover:bg-gray-200 dark:hover:bg-gray-700 rounded"
-          aria-label={node.children ? 'Collapse' : 'Expand'}
-        >
-          <svg
-            className={`w-3 h-3 text-gray-500 transform transition-transform ${
-              node.children ? 'rotate-90' : ''
-            }`}
-            fill="currentColor"
-            viewBox="0 0 20 20"
+      {/* One guide per ancestor level, so files and directories share an indent */}
+      {Array.from({ length: depth }, (_, level) => (
+        <span
+          key={level}
+          data-indent-guide
+          aria-hidden="true"
+          className="h-full w-4 flex-shrink-0 border-r border-gray-200 dark:border-gray-800"
+        />
+      ))}
+
+      {/* Disclosure slot, kept for files so their content lines up with sibling directories */}
+      <span data-disclosure-slot className="flex h-5 w-5 flex-shrink-0 items-center justify-center">
+        {isDirectory && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              handleToggle();
+            }}
+            className="flex h-5 w-5 items-center justify-center rounded text-gray-400 transition-colors hover:bg-gray-200 hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+            aria-expanded={isExpanded}
+            aria-label={isExpanded ? 'Collapse' : 'Expand'}
           >
-            <path
-              fillRule="evenodd"
-              d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-              clipRule="evenodd"
-            />
-          </svg>
-        </button>
-      )}
+            <svg
+              className={`w-3 h-3 transform transition-transform ${isExpanded ? 'rotate-90' : ''}`}
+              fill="currentColor"
+              viewBox="0 0 20 20"
+            >
+              <path
+                fillRule="evenodd"
+                d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </button>
+        )}
+      </span>
 
       {/* Checkbox - hidden for excluded files */}
-      {!isExcluded && (
+      {!isExcluded ? (
         <input
           type="checkbox"
           checked={checkboxState === 'checked'}
@@ -121,13 +146,12 @@ export function FileTreeNode({
           }}
           onChange={handleCheckboxChange}
           onClick={(e) => e.stopPropagation()}
-          className="flex-shrink-0 rounded border-gray-300 text-primary-600 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800"
+          className="h-4 w-4 flex-shrink-0 cursor-pointer rounded accent-primary-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
           aria-label={`Select ${node.name}`}
         />
-      )}
-      {/* Spacer for excluded files to maintain alignment */}
-      {isExcluded && (
-        <div className="w-4 h-4 flex-shrink-0" />
+      ) : (
+        /* Spacer for excluded files to maintain alignment */
+        <div className="h-4 w-4 flex-shrink-0" />
       )}
 
       {/* Icon */}
@@ -135,10 +159,10 @@ export function FileTreeNode({
 
       {/* Name */}
       <span
-        className={`flex-1 text-sm truncate ${
+        className={`flex-1 truncate ${isDirectory ? 'font-medium' : ''} ${
           isExcluded
-            ? 'text-gray-400 dark:text-gray-600 line-through'
-            : 'text-gray-900 dark:text-gray-100'
+            ? 'text-gray-400 line-through dark:text-gray-600'
+            : 'text-gray-800 dark:text-gray-200'
         }`}
         title={node.name}
       >

--- a/src/components/file-tree/__tests__/FileTree.test.tsx
+++ b/src/components/file-tree/__tests__/FileTree.test.tsx
@@ -31,11 +31,10 @@ describe('FileTree', () => {
   ];
 
   it('should render file tree', () => {
-    const { container } = render(<FileTree nodes={mockNodes} />);
+    render(<FileTree nodes={mockNodes} />);
 
     // Check that the tree container is rendered
-    const treeContainer = container.querySelector('.border');
-    expect(treeContainer).toBeInTheDocument();
+    expect(screen.getByTestId('file-tree')).toBeInTheDocument();
   });
 
   it('should render empty state when no nodes', () => {

--- a/src/components/file-tree/__tests__/FileTreeNode.test.tsx
+++ b/src/components/file-tree/__tests__/FileTreeNode.test.tsx
@@ -53,11 +53,30 @@ describe('FileTreeNode', () => {
     expect(onToggle).toHaveBeenCalledWith('src');
   });
 
-  it('should render with correct indentation', () => {
-    render(<FileTreeNode node={mockFileNode} depth={2} />);
+  it('should render one indent guide per ancestor level', () => {
+    const { container } = render(<FileTreeNode node={mockFileNode} depth={2} />);
 
-    const node = screen.getByText('test.ts').closest('div');
-    expect(node).toHaveStyle({ paddingLeft: '48px' }); // depth * 20 + 8
+    expect(container.querySelectorAll('[data-indent-guide]')).toHaveLength(2);
+  });
+
+  it('should indent files and directories at the same depth identically', () => {
+    const file = render(<FileTreeNode node={mockFileNode} depth={2} />);
+    const directory = render(<FileTreeNode node={mockDirNode} depth={2} />);
+
+    // Files keep an empty disclosure slot so their content lines up with sibling directories
+    expect(file.container.querySelectorAll('[data-indent-guide]')).toHaveLength(2);
+    expect(directory.container.querySelectorAll('[data-indent-guide]')).toHaveLength(2);
+    expect(file.container.querySelector('[data-disclosure-slot]')).toBeInTheDocument();
+    expect(directory.container.querySelector('[data-disclosure-slot]')).toBeInTheDocument();
+  });
+
+  it('should select a file when its row is clicked', () => {
+    const onSelect = vi.fn();
+    render(<FileTreeNode node={mockFileNode} depth={0} onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByText('test.ts'));
+
+    expect(onSelect).toHaveBeenCalledWith('src/test.ts', true);
   });
 
   it('should render checked checkbox for selected node', () => {

--- a/src/components/filters/ExtensionFilter.tsx
+++ b/src/components/filters/ExtensionFilter.tsx
@@ -3,7 +3,6 @@
  * Allows filtering files by extension
  */
 
-import { Button } from '../ui/Button';
 import type { ExtensionFilter as ExtensionFilterType } from '@/types';
 
 interface ExtensionFilterProps {
@@ -19,52 +18,47 @@ export function ExtensionFilter({
   onSelectAll,
   onDeselectAll,
 }: ExtensionFilterProps) {
-  const selectedCount = extensions.filter((e) => e.selected).length;
+  // Partially selected extensions still contribute files to the output
+  const includedCount = extensions.filter((e) => e.selected || e.indeterminate).length;
   const totalCount = extensions.length;
 
   return (
-    <div className="space-y-3">
-      {/* Summary */}
-      <div className="flex items-center justify-end">
-        <span className="text-xs text-gray-500 dark:text-gray-400">
-          {selectedCount} of {totalCount} selected
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-3">
+        <span className="tabular-nums text-xs text-gray-500 dark:text-gray-400">
+          {includedCount} of {totalCount} included
         </span>
-      </div>
-
-      {/* Batch actions */}
-      <div className="flex gap-2">
-        <Button
-          variant="secondary"
-          size="sm"
-          onClick={onSelectAll}
-          className="flex-1"
-        >
-          Select All
-        </Button>
-        <Button
-          variant="secondary"
-          size="sm"
-          onClick={onDeselectAll}
-          className="flex-1"
-        >
-          Deselect All
-        </Button>
+        <div className="flex items-center gap-3 text-xs">
+          <button
+            onClick={onSelectAll}
+            className="text-primary-600 transition-colors hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
+          >
+            Select all
+          </button>
+          <span className="text-gray-300 dark:text-gray-700">|</span>
+          <button
+            onClick={onDeselectAll}
+            className="text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
+          >
+            Clear
+          </button>
+        </div>
       </div>
 
       {/* Extension list */}
-      <div className="max-h-64 overflow-y-auto border border-gray-300 dark:border-gray-700 rounded-lg">
+      <div className="max-h-64 overflow-y-auto rounded-md border border-gray-200 dark:border-gray-800">
         {extensions.length === 0 ? (
           <div className="p-4 text-center text-sm text-gray-500 dark:text-gray-400">
             No file extensions found
           </div>
         ) : (
-          <div className="divide-y divide-gray-200 dark:divide-gray-700">
+          <div className="divide-y divide-gray-100 dark:divide-gray-800">
             {extensions.map((ext) => (
               <label
                 key={ext.extension}
-                className="flex items-center justify-between p-2 hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer"
+                className="flex cursor-pointer items-center justify-between gap-3 px-2.5 py-1.5 transition-colors hover:bg-gray-50 dark:hover:bg-gray-800/60"
               >
-                <div className="flex items-center gap-2 flex-1">
+                <div className="flex flex-1 items-center gap-2.5">
                   <input
                     type="checkbox"
                     checked={ext.selected}
@@ -74,13 +68,13 @@ export function ExtensionFilter({
                       }
                     }}
                     onChange={() => onToggle?.(ext.extension)}
-                    className="rounded border-gray-300 text-primary-600 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800"
+                    className="h-4 w-4 cursor-pointer rounded accent-primary-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                   />
-                  <span className="text-sm text-gray-900 dark:text-gray-100 font-mono">
+                  <span className="font-mono text-sm text-gray-800 dark:text-gray-200">
                     {ext.extension}
                   </span>
                 </div>
-                <span className="text-xs text-gray-500 dark:text-gray-400">
+                <span className="tabular-nums text-xs text-gray-500 dark:text-gray-400">
                   {ext.count}
                 </span>
               </label>

--- a/src/components/filters/GitIgnoreEditor.tsx
+++ b/src/components/filters/GitIgnoreEditor.tsx
@@ -68,17 +68,22 @@ export function GitIgnoreEditor({
     setHasChanges(false);
   };
 
-  const handleAddSuggestion = (pattern: string) => {
-    const currentPatterns = patterns ? patterns + '\n' : '';
-    setPatterns(currentPatterns + pattern);
-    setHasChanges(true);
-  };
-
   const handleChange = (value: string) => {
     setPatterns(value);
     const patternsChanged = value !== initialPatterns.join('\n');
     const checkboxChanged = localShowExcluded !== showExcluded;
     setHasChanges(patternsChanged || checkboxChanged);
+  };
+
+  const handleToggleSuggestion = (pattern: string) => {
+    const lines = patterns.split('\n');
+    const isActive = lines.some((line) => line.trim() === pattern);
+
+    handleChange(
+      isActive
+        ? lines.filter((line) => line.trim() !== pattern).join('\n')
+        : [...(patterns.trim() ? [patterns.replace(/\n+$/, '')] : []), pattern].join('\n')
+    );
   };
 
   const handleCheckboxChange = (checked: boolean) => {
@@ -88,9 +93,9 @@ export function GitIgnoreEditor({
     setHasChanges(patternsChanged || checkboxChanged);
   };
 
-  const patternCount = patterns
-    .split('\n')
-    .filter((p) => p.trim() && !p.trim().startsWith('#')).length;
+  const patternLines = patterns.split('\n').map((p) => p.trim());
+  const patternCount = patternLines.filter((p) => p && !p.startsWith('#')).length;
+  const activePatterns = new Set(patternLines);
 
   return (
     <div className="space-y-3">
@@ -167,15 +172,24 @@ export function GitIgnoreEditor({
 
         {showSuggestions && (
           <div className="mt-2 grid grid-cols-2 gap-1">
-            {COMMON_PATTERNS.map((pattern) => (
-              <button
-                key={pattern}
-                onClick={() => handleAddSuggestion(pattern)}
-                className="rounded border border-gray-200 px-2 py-1 text-left font-mono text-xs text-gray-600 transition-colors hover:border-gray-300 hover:text-gray-900 dark:border-gray-800 dark:text-gray-400 dark:hover:border-gray-700 dark:hover:text-gray-100"
-              >
-                {pattern}
-              </button>
-            ))}
+            {COMMON_PATTERNS.map((pattern) => {
+              const isActive = activePatterns.has(pattern);
+
+              return (
+                <button
+                  key={pattern}
+                  onClick={() => handleToggleSuggestion(pattern)}
+                  aria-pressed={isActive}
+                  className={`rounded border px-2 py-1 text-left font-mono text-xs transition-colors ${
+                    isActive
+                      ? 'border-primary-500 bg-primary-50 text-primary-700 dark:bg-primary-500/10 dark:text-primary-300'
+                      : 'border-gray-200 text-gray-600 hover:border-gray-300 hover:text-gray-900 dark:border-gray-800 dark:text-gray-400 dark:hover:border-gray-700 dark:hover:text-gray-100'
+                  }`}
+                >
+                  {pattern}
+                </button>
+              );
+            })}
           </div>
         )}
       </div>

--- a/src/components/filters/GitIgnoreEditor.tsx
+++ b/src/components/filters/GitIgnoreEditor.tsx
@@ -94,76 +94,63 @@ export function GitIgnoreEditor({
 
   return (
     <div className="space-y-3">
-      {/* Summary */}
-      <div className="flex items-center justify-end">
-        <span className="text-xs text-gray-500 dark:text-gray-400">
-          {patternCount} {patternCount === 1 ? 'pattern' : 'patterns'}
-        </span>
-      </div>
-
       {/* Pattern input */}
       <div className="space-y-2">
         <textarea
           value={patterns}
           onChange={(e) => handleChange(e.target.value)}
           placeholder="# Enter gitignore patterns (one per line)&#10;node_modules/&#10;*.log&#10;.env"
-          className="w-full h-48 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm font-mono text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:focus:ring-primary-400 resize-none"
+          className="h-40 w-full resize-none rounded-md border border-gray-200 bg-white px-3 py-2 font-mono text-sm text-gray-900 placeholder-gray-400 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-100 dark:placeholder-gray-600"
         />
 
-        <div className="text-xs text-gray-500 dark:text-gray-400">
-          <p>• Use <code className="bg-gray-100 dark:bg-gray-800 px-1 rounded">#</code> for comments</p>
-          <p>• Add <code className="bg-gray-100 dark:bg-gray-800 px-1 rounded">/</code> at the end for directories</p>
-          <p>• Use <code className="bg-gray-100 dark:bg-gray-800 px-1 rounded">*</code> for wildcards</p>
-        </div>
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          One per line. <code className="rounded bg-gray-100 px-1 dark:bg-gray-800">#</code> comments,{' '}
+          <code className="rounded bg-gray-100 px-1 dark:bg-gray-800">/</code> for directories,{' '}
+          <code className="rounded bg-gray-100 px-1 dark:bg-gray-800">*</code> for wildcards.
+        </p>
       </div>
 
       {/* Show excluded files toggle */}
       <div className="space-y-1">
-        <label className="flex items-center gap-2 p-2 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer">
+        <label className="flex cursor-pointer items-center gap-2.5 rounded-md py-1 transition-colors">
           <input
             type="checkbox"
             checked={localShowExcluded}
             onChange={(e) => handleCheckboxChange(e.target.checked)}
-            className="rounded border-gray-300 text-primary-600 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800"
+            className="h-4 w-4 cursor-pointer rounded accent-primary-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
           />
-          <span className="text-sm text-gray-900 dark:text-gray-100">
+          <span className="text-sm text-gray-800 dark:text-gray-200">
             Show excluded files in directory tree
           </span>
         </label>
-        <p className="text-xs text-gray-500 dark:text-gray-400 pl-8">
-          Controls visibility in output directory tree. Excluded file contents are never included.
+        <p className="pl-[26px] text-xs text-gray-500 dark:text-gray-400">
+          Their contents are never included.
         </p>
       </div>
 
       {/* Actions */}
-      <div className="flex gap-2">
-        <Button
-          variant="primary"
-          size="sm"
-          onClick={handleApply}
-          disabled={!hasChanges}
-          className="flex-1"
-        >
-          Apply Patterns
-        </Button>
-        <Button
-          variant="secondary"
-          size="sm"
-          onClick={handleReset}
-          className="flex-1"
-        >
-          Reset
-        </Button>
+      <div className="flex items-center justify-between gap-3">
+        <span className="tabular-nums text-xs text-gray-500 dark:text-gray-400">
+          {patternCount} {patternCount === 1 ? 'pattern' : 'patterns'}
+        </span>
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="sm" onClick={handleReset} className="text-gray-500 dark:text-gray-400">
+            Reset
+          </Button>
+          <Button variant="primary" size="sm" onClick={handleApply} disabled={!hasChanges}>
+            Apply Patterns
+          </Button>
+        </div>
       </div>
 
       {/* Pattern suggestions */}
       <div>
         <button
           onClick={() => setShowSuggestions(!showSuggestions)}
-          className="flex items-center gap-1 text-sm text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300"
+          className="flex items-center gap-1 text-xs text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
         >
           <svg
-            className={`w-4 h-4 transform transition-transform ${
+            className={`h-3 w-3 transform transition-transform ${
               showSuggestions ? 'rotate-90' : ''
             }`}
             fill="currentColor"
@@ -175,7 +162,7 @@ export function GitIgnoreEditor({
               clipRule="evenodd"
             />
           </svg>
-          Common Patterns
+          Common patterns
         </button>
 
         {showSuggestions && (
@@ -184,7 +171,7 @@ export function GitIgnoreEditor({
               <button
                 key={pattern}
                 onClick={() => handleAddSuggestion(pattern)}
-                className="text-left px-2 py-1 text-xs font-mono rounded bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700"
+                className="rounded border border-gray-200 px-2 py-1 text-left font-mono text-xs text-gray-600 transition-colors hover:border-gray-300 hover:text-gray-900 dark:border-gray-800 dark:text-gray-400 dark:hover:border-gray-700 dark:hover:text-gray-100"
               >
                 {pattern}
               </button>

--- a/src/components/filters/__tests__/ExtensionFilter.test.tsx
+++ b/src/components/filters/__tests__/ExtensionFilter.test.tsx
@@ -29,7 +29,7 @@ describe('ExtensionFilter', () => {
   it('should show selected count', () => {
     render(<ExtensionFilter extensions={mockExtensions} />);
 
-    expect(screen.getByText('2 of 3 selected')).toBeInTheDocument();
+    expect(screen.getByText('2 of 3 included')).toBeInTheDocument();
   });
 
   it('should call onToggle when checkbox is clicked', () => {
@@ -46,7 +46,7 @@ describe('ExtensionFilter', () => {
     const onSelectAll = vi.fn();
     render(<ExtensionFilter extensions={mockExtensions} onSelectAll={onSelectAll} />);
 
-    const selectAllButton = screen.getByText('Select All');
+    const selectAllButton = screen.getByText('Select all');
     fireEvent.click(selectAllButton);
 
     expect(onSelectAll).toHaveBeenCalled();
@@ -56,7 +56,7 @@ describe('ExtensionFilter', () => {
     const onDeselectAll = vi.fn();
     render(<ExtensionFilter extensions={mockExtensions} onDeselectAll={onDeselectAll} />);
 
-    const deselectAllButton = screen.getByText('Deselect All');
+    const deselectAllButton = screen.getByText('Clear');
     fireEvent.click(deselectAllButton);
 
     expect(onDeselectAll).toHaveBeenCalled();

--- a/src/components/filters/__tests__/GitIgnoreEditor.test.tsx
+++ b/src/components/filters/__tests__/GitIgnoreEditor.test.tsx
@@ -32,6 +32,35 @@ describe('GitIgnoreEditor', () => {
     expect(onApply).toHaveBeenCalledWith(['node_modules/', '*.log', '.env', 'dist/']);
   });
 
+  it('should add a common pattern once and remove it on a second click', async () => {
+    render(<GitIgnoreEditor patterns={[]} />);
+
+    await userEvent.click(screen.getByText('Common patterns'));
+    const suggestion = screen.getByRole('button', { name: 'dist/' });
+
+    await userEvent.click(suggestion);
+    const textarea = screen.getByPlaceholderText(/Enter gitignore patterns/) as HTMLTextAreaElement;
+    expect(textarea.value).toBe('dist/');
+    expect(suggestion).toHaveAttribute('aria-pressed', 'true');
+
+    await userEvent.click(suggestion);
+    expect(textarea.value).toBe('');
+    expect(suggestion).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('should keep existing patterns when toggling a suggestion', async () => {
+    render(<GitIgnoreEditor patterns={['node_modules/', '*.log']} />);
+
+    await userEvent.click(screen.getByText('Common patterns'));
+    await userEvent.click(screen.getByRole('button', { name: 'dist/' }));
+
+    const textarea = screen.getByPlaceholderText(/Enter gitignore patterns/) as HTMLTextAreaElement;
+    expect(textarea.value).toBe('node_modules/\n*.log\ndist/');
+
+    await userEvent.click(screen.getByRole('button', { name: '*.log' }));
+    expect(textarea.value).toBe('node_modules/\ndist/');
+  });
+
   it('should call onReset when Reset button is clicked', () => {
     const onReset = vi.fn();
     render(<GitIgnoreEditor patterns={mockPatterns} onReset={onReset} />);

--- a/src/components/filters/__tests__/GitIgnoreEditor.test.tsx
+++ b/src/components/filters/__tests__/GitIgnoreEditor.test.tsx
@@ -76,7 +76,7 @@ describe('GitIgnoreEditor', () => {
   it('should show common patterns when expanded', async () => {
     render(<GitIgnoreEditor patterns={[]} />);
 
-    const toggleButton = screen.getByText('Common Patterns');
+    const toggleButton = screen.getByText('Common patterns');
     await userEvent.click(toggleButton);
 
     expect(screen.getByText('node_modules/')).toBeInTheDocument();
@@ -86,7 +86,7 @@ describe('GitIgnoreEditor', () => {
   it('should add common pattern when clicked', async () => {
     render(<GitIgnoreEditor patterns={[]} />);
 
-    const toggleButton = screen.getByText('Common Patterns');
+    const toggleButton = screen.getByText('Common patterns');
     await userEvent.click(toggleButton);
 
     const patternButton = screen.getByText('node_modules/');

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -14,7 +14,8 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         ref={ref}
         className={cn(
           'inline-flex items-center justify-center rounded-md font-medium transition-colors',
-          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500',
+          'focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-900',
           'disabled:pointer-events-none disabled:opacity-50',
           'touch-manipulation', // Improves touch responsiveness
           {

--- a/src/components/ui/ErrorDialog.tsx
+++ b/src/components/ui/ErrorDialog.tsx
@@ -3,7 +3,8 @@
  * Displays user-friendly error messages with optional recovery actions
  */
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
+import { Button } from './Button';
 
 interface ErrorDialogProps {
   title?: string;
@@ -14,12 +15,14 @@ interface ErrorDialogProps {
 }
 
 export function ErrorDialog({
-  title = 'Oops! Something went wrong',
+  title = 'Something went wrong',
   message,
   onClose,
   onAction,
   actionLabel = 'Help',
 }: ErrorDialogProps) {
+  const closeRef = useRef<HTMLButtonElement>(null);
+
   // Close on Escape key
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
@@ -29,58 +32,51 @@ export function ErrorDialog({
     return () => window.removeEventListener('keydown', handleEscape);
   }, [onClose]);
 
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm">
-      <div className="bg-white dark:bg-gray-900 rounded-lg shadow-xl max-w-md w-full border border-gray-200 dark:border-gray-700">
-        {/* Header */}
-        <div className="flex items-start justify-between p-6 pb-4">
-          <div className="flex items-start gap-3">
-            <div className="flex-shrink-0 w-10 h-10 rounded-full bg-red-100 dark:bg-red-900/20 flex items-center justify-center">
-              <svg className="w-6 h-6 text-red-600 dark:text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-              </svg>
-            </div>
-            <div>
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-                {title}
-              </h3>
-            </div>
-          </div>
-          <button
-            onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
+  // Move focus into the dialog so keyboard users land on a control
+  useEffect(() => {
+    closeRef.current?.focus();
+  }, []);
 
-        {/* Message */}
-        <div className="px-6 pb-6">
-          <p className="text-sm text-gray-600 dark:text-gray-400 whitespace-pre-line">
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-gray-950/60 p-4 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="error-dialog-title"
+        onClick={(e) => e.stopPropagation()}
+        className="w-full max-w-md rounded-lg border border-gray-200 bg-white shadow-xl dark:border-gray-800 dark:bg-gray-900"
+      >
+        <div className="space-y-2 p-5">
+          <h3
+            id="error-dialog-title"
+            className="text-sm font-semibold text-gray-900 dark:text-gray-100"
+          >
+            {title}
+          </h3>
+          <p className="whitespace-pre-line text-sm leading-relaxed text-gray-600 dark:text-gray-400">
             {message}
           </p>
         </div>
 
         {/* Actions */}
-        <div className="flex gap-3 p-6 pt-0 border-t border-gray-200 dark:border-gray-700">
-          <button
-            onClick={onClose}
-            className="flex-1 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-md transition-colors"
-          >
+        <div className="flex justify-end gap-2 border-t border-gray-200 p-3 dark:border-gray-800">
+          <Button ref={closeRef} variant="secondary" size="sm" onClick={onClose}>
             Close
-          </button>
+          </Button>
           {onAction && (
-            <button
+            <Button
+              variant="primary"
+              size="sm"
               onClick={() => {
                 onAction();
                 onClose();
               }}
-              className="flex-1 px-4 py-2 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 dark:bg-primary-500 dark:hover:bg-primary-600 rounded-md transition-colors"
             >
               {actionLabel}
-            </button>
+            </Button>
           )}
         </div>
       </div>

--- a/src/components/ui/Panel.tsx
+++ b/src/components/ui/Panel.tsx
@@ -1,0 +1,24 @@
+import { forwardRef } from 'react';
+import type { HTMLAttributes } from 'react';
+import { cn } from '@/lib/utils';
+
+/**
+ * Bordered surface shared by every top-level section of the workspace.
+ * Sections are flat by design: nested regions use dividers, not more borders.
+ */
+const Panel = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        'rounded-lg border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900',
+        className
+      )}
+      {...props}
+    />
+  )
+);
+
+Panel.displayName = 'Panel';
+
+export { Panel };

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -15,9 +15,33 @@ export function ThemeToggle() {
   };
 
   const getIcon = () => {
-    if (theme === 'light') return '☀️';
-    if (theme === 'dark') return '🌙';
-    return '💻';
+    if (theme === 'light') {
+      return (
+        <svg className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={1.75} viewBox="0 0 24 24">
+          <circle cx="12" cy="12" r="4" />
+          <path strokeLinecap="round" d="M12 3v2m0 14v2M5.6 5.6l1.4 1.4m10 10l1.4 1.4M3 12h2m14 0h2M5.6 18.4L7 17m10-10l1.4-1.4" />
+        </svg>
+      );
+    }
+
+    if (theme === 'dark') {
+      return (
+        <svg className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={1.75} viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M20 14.5A8 8 0 019.5 4a8.5 8.5 0 1010.5 10.5z"
+          />
+        </svg>
+      );
+    }
+
+    return (
+      <svg className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={1.75} viewBox="0 0 24 24">
+        <rect x="3" y="4" width="18" height="12" rx="2" />
+        <path strokeLinecap="round" d="M9 20h6" />
+      </svg>
+    );
   };
 
   const getLabel = () => {
@@ -32,11 +56,13 @@ export function ThemeToggle() {
       size="sm"
       onClick={toggleTheme}
       title={`Current theme: ${getLabel()}`}
-      className="gap-2"
+      className="gap-2 text-gray-600 dark:text-gray-400"
       data-testid="theme-toggle"
     >
-      <span className="text-lg" data-testid="theme-icon">{getIcon()}</span>
-      <span className="hidden sm:inline" data-testid="theme-label">{getLabel()}</span>
+      <span data-testid="theme-icon">{getIcon()}</span>
+      <span className="hidden text-xs sm:inline" data-testid="theme-label">
+        {getLabel()}
+      </span>
     </Button>
   );
 }

--- a/src/features/github/GitHubProvider.ts
+++ b/src/features/github/GitHubProvider.ts
@@ -4,7 +4,7 @@
  */
 
 import { BaseProvider } from '@/lib/providers/BaseProvider';
-import { ProviderError, ErrorCode } from '@/lib/providers/types';
+import { HttpError, ProviderError, ErrorCode } from '@/lib/providers/types';
 import type { ParsedRepoInfo } from '@/lib/providers/types';
 import type { ProviderType, FileNode, FetchOptions, FileContent } from '@/types';
 
@@ -326,37 +326,62 @@ export class GitHubProvider extends BaseProvider {
       return error;
     }
 
-    if (error instanceof Error) {
-      const message = error.message;
+    if (error instanceof HttpError && (error.status === 403 || error.status === 429)) {
+      const isQuotaExhausted =
+        error.status === 429 ||
+        error.rateLimitRemaining === 0 ||
+        error.retryAfterSeconds !== undefined ||
+        /rate limit/i.test(error.apiMessage || '');
 
-      // 403 on GitHub usually means rate limit (60 requests/hour for unauthenticated)
-      // or authentication required for private repos
-      if (message.includes('403')) {
+      // A private repository refusing an anonymous reader also answers 403
+      if (!isQuotaExhausted) {
         return new ProviderError(
-          message,
-          ErrorCode.RATE_LIMITED,
-          `GitHub API rate limit exceeded or authentication required${contextMsg}.
-
-Unauthenticated requests are limited to 60/hour. Please add a GitHub Personal Access Token to increase the limit to 5,000/hour.
-
-Click the GitHub icon in the authentication section above to add a token.`,
-          () => {
-            window.open('https://github.com/settings/tokens/new?description=repo2txt&scopes=repo', '_blank');
-          }
+          error.message,
+          ErrorCode.AUTH_FAILED,
+          `GitHub denied access${contextMsg}.${
+            error.apiMessage ? `\n\n${error.apiMessage}` : ''
+          }\n\nPrivate repositories need a Personal Access Token with repo scope.`,
+          this.openTokenPage
         );
       }
 
-      // 429 is explicit rate limiting
-      if (message.includes('429')) {
-        return new ProviderError(
-          message,
-          ErrorCode.RATE_LIMITED,
-          `GitHub API rate limit exceeded${contextMsg}. Please wait a moment and try again.`
-        );
-      }
+      const hasToken = Boolean(this.credentials?.token);
+      const quota = hasToken ? '5,000' : '60';
+      const resetsIn = error.rateLimitReset ? this.describeReset(error.rateLimitReset) : null;
+
+      return new ProviderError(
+        error.message,
+        ErrorCode.RATE_LIMITED,
+        `GitHub API rate limit reached${contextMsg}.
+
+Every file is fetched as its own API request, so a large repository can use the ${quota} requests per hour that ${
+          hasToken ? 'a token allows' : 'anonymous access allows'
+        }.${resetsIn ? ` The limit resets ${resetsIn}.` : ''}
+
+${
+  hasToken
+    ? 'Select fewer files, or wait for the limit to reset.'
+    : 'Add a Personal Access Token to raise the limit to 5,000 requests per hour, or select fewer files.'
+}`,
+        hasToken ? undefined : this.openTokenPage
+      );
     }
 
     // Use base class error handling for other errors
     return super.handleFetchError(error, context);
   }
+
+  /**
+   * Describe when a rate limit window reopens in terms a reader can act on
+   */
+  private describeReset(reset: Date): string {
+    const minutes = Math.max(1, Math.ceil((reset.getTime() - Date.now()) / 60000));
+    return minutes > 60
+      ? `at ${reset.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}`
+      : `in ${minutes} minute${minutes === 1 ? '' : 's'}`;
+  }
+
+  private openTokenPage = () => {
+    window.open('https://github.com/settings/tokens/new?description=repo2txt&scopes=repo', '_blank');
+  };
 }

--- a/src/features/github/GitHubProvider.ts
+++ b/src/features/github/GitHubProvider.ts
@@ -49,7 +49,9 @@ export class GitHubProvider extends BaseProvider {
       ? normalized.replace(/^https?:\/\//i, 'https://')
       : `https://${normalized.replace(/^\/+/, '')}`;
 
-    return normalized.replace(/^https:\/\/www\./i, 'https://').replace(/\.git$/, '');
+    return normalized
+      .replace(/^https:\/\/www\./i, 'https://')
+      .replace(/^(https:\/\/github\.com\/[^/]+\/[^/]+)\.git$/i, '$1');
   }
 
   /**

--- a/src/features/github/GitHubProvider.ts
+++ b/src/features/github/GitHubProvider.ts
@@ -34,25 +34,43 @@ export class GitHubProvider extends BaseProvider {
   }
 
   /**
+   * Bring the shapes people paste into a single canonical form
+   * Covers a missing or plain http scheme, www, ssh remotes and .git suffixes
+   */
+  static normalizeUrl(url: string): string {
+    let normalized = url.trim().replace(/\/+$/, '');
+
+    const sshMatch = normalized.match(/^git@github\.com:(.+)$/i);
+    if (sshMatch) {
+      normalized = `https://github.com/${sshMatch[1]}`;
+    }
+
+    normalized = /^https?:\/\//i.test(normalized)
+      ? normalized.replace(/^https?:\/\//i, 'https://')
+      : `https://${normalized.replace(/^\/+/, '')}`;
+
+    return normalized.replace(/^https:\/\/www\./i, 'https://').replace(/\.git$/, '');
+  }
+
+  /**
    * Validate GitHub URL format
    */
   validateUrl(url: string): boolean {
-    const normalized = url.replace(/\/$/, ''); // Remove trailing slash
-    return GitHubProvider.URL_PATTERN.test(normalized);
+    return GitHubProvider.URL_PATTERN.test(GitHubProvider.normalizeUrl(url));
   }
 
   /**
    * Parse GitHub URL to extract repository information
    */
   parseUrl(url: string): ParsedRepoInfo {
-    const normalized = url.replace(/\/$/, '');
+    const normalized = GitHubProvider.normalizeUrl(url);
     const match = normalized.match(GitHubProvider.URL_PATTERN);
 
     if (!match) {
       return {
         url,
         isValid: false,
-        error: 'Invalid GitHub URL format. Expected: https://github.com/owner/repo',
+        error: 'Invalid GitHub URL format. Expected: github.com/owner/repo',
       };
     }
 

--- a/src/features/github/__tests__/GitHubProvider.test.ts
+++ b/src/features/github/__tests__/GitHubProvider.test.ts
@@ -136,6 +136,14 @@ describe('GitHubProvider', () => {
       expect(result.repo).toBe('repo');
     });
 
+    it('should keep a branch or path that ends in .git', () => {
+      const branch = provider.parseUrl('https://github.com/owner/repo/tree/release.git');
+      expect(branch.branch).toBe('release.git');
+
+      const path = provider.parseUrl('https://github.com/owner/repo/tree/main/vendor/foo.git');
+      expect(path.branch).toBe('main/vendor/foo.git');
+    });
+
     it('should parse an ssh remote', () => {
       const result = provider.parseUrl('git@github.com:owner/repo.git');
 
@@ -303,6 +311,22 @@ describe('GitHubProvider', () => {
         http.get('https://api.github.com/repos/:owner/:repo/contents', () => {
           attempts += 1;
           return HttpResponse.json({ message: 'Bad credentials' }, { status: 401 });
+        })
+      );
+
+      await expect(provider.fetchTree('https://github.com/owner/repo')).rejects.toThrow();
+      expect(attempts).toBe(1);
+    });
+
+    it('should not sit through a long Retry-After on a server error', async () => {
+      let attempts = 0;
+      server.use(
+        http.get('https://api.github.com/repos/:owner/:repo/contents', () => {
+          attempts += 1;
+          return HttpResponse.json(
+            { message: 'Service unavailable' },
+            { status: 503, headers: { 'retry-after': '3600' } }
+          );
         })
       );
 

--- a/src/features/github/__tests__/GitHubProvider.test.ts
+++ b/src/features/github/__tests__/GitHubProvider.test.ts
@@ -235,6 +235,81 @@ describe('GitHubProvider', () => {
       await expect(provider.fetchTree('https://github.com/owner/repo')).rejects.toThrow();
     });
 
+    it('should report the rate limit with the reset window and how the quota is spent', async () => {
+      server.use(
+        http.get('https://api.github.com/repos/:owner/:repo/contents', () => {
+          return HttpResponse.json(
+            { message: 'API rate limit exceeded for 203.0.113.4.' },
+            {
+              status: 403,
+              headers: {
+                'x-ratelimit-remaining': '0',
+                'x-ratelimit-reset': String(Math.floor(Date.now() / 1000) + 600),
+              },
+            }
+          );
+        })
+      );
+
+      try {
+        await provider.fetchTree('https://github.com/owner/repo');
+        expect.fail('Should have thrown an error');
+      } catch (error: unknown) {
+        const providerError = error as { code: string; userMessage: string; recovery?: () => void };
+        expect(providerError.code).toBe(ErrorCode.RATE_LIMITED);
+        expect(providerError.userMessage).toContain('own API request');
+        expect(providerError.userMessage).toContain('10 minutes');
+        expect(providerError.recovery).toBeDefined();
+      }
+    });
+
+    it('should report an invalid token instead of an unexpected error', async () => {
+      server.use(
+        http.get('https://api.github.com/repos/:owner/:repo/contents', () => {
+          return HttpResponse.json({ message: 'Bad credentials' }, { status: 401 });
+        })
+      );
+
+      try {
+        await provider.fetchTree('https://github.com/owner/repo');
+        expect.fail('Should have thrown an error');
+      } catch (error: unknown) {
+        const providerError = error as { code: string; userMessage: string };
+        expect(providerError.code).toBe(ErrorCode.AUTH_FAILED);
+        expect(providerError.userMessage).toContain('Bad credentials');
+      }
+    });
+
+    it('should name the status when GitHub fails in a way we do not model', async () => {
+      server.use(
+        http.get('https://api.github.com/repos/:owner/:repo/contents', () => {
+          return HttpResponse.json({ message: 'Repository is disabled' }, { status: 451 });
+        })
+      );
+
+      try {
+        await provider.fetchTree('https://github.com/owner/repo');
+        expect.fail('Should have thrown an error');
+      } catch (error: unknown) {
+        const providerError = error as { userMessage: string };
+        expect(providerError.userMessage).toContain('HTTP 451');
+        expect(providerError.userMessage).toContain('Repository is disabled');
+      }
+    });
+
+    it('should not retry a request the API rejected outright', async () => {
+      let attempts = 0;
+      server.use(
+        http.get('https://api.github.com/repos/:owner/:repo/contents', () => {
+          attempts += 1;
+          return HttpResponse.json({ message: 'Bad credentials' }, { status: 401 });
+        })
+      );
+
+      await expect(provider.fetchTree('https://github.com/owner/repo')).rejects.toThrow();
+      expect(attempts).toBe(1);
+    });
+
     it('should handle rate limit errors', async () => {
       server.use(
         http.get('https://api.github.com/repos/:owner/:repo/contents', () => {

--- a/src/features/github/__tests__/GitHubProvider.test.ts
+++ b/src/features/github/__tests__/GitHubProvider.test.ts
@@ -112,9 +112,38 @@ describe('GitHubProvider', () => {
       expect(provider.validateUrl('not-a-url')).toBe(false);
       expect(provider.validateUrl('')).toBe(false);
     });
+
+    it('should accept a URL without a scheme', () => {
+      expect(provider.validateUrl('github.com/owner/repo')).toBe(true);
+      expect(provider.validateUrl('www.github.com/owner/repo')).toBe(true);
+      expect(provider.validateUrl('github.com/owner/repo/tree/main')).toBe(true);
+    });
+
+    it('should accept http, ssh remotes, .git suffixes and stray whitespace', () => {
+      expect(provider.validateUrl('http://github.com/owner/repo')).toBe(true);
+      expect(provider.validateUrl('git@github.com:owner/repo.git')).toBe(true);
+      expect(provider.validateUrl('https://github.com/owner/repo.git')).toBe(true);
+      expect(provider.validateUrl('  github.com/owner/repo  ')).toBe(true);
+    });
   });
 
   describe('parseUrl', () => {
+    it('should parse a URL entered without a scheme', () => {
+      const result = provider.parseUrl('github.com/owner/repo');
+
+      expect(result.isValid).toBe(true);
+      expect(result.owner).toBe('owner');
+      expect(result.repo).toBe('repo');
+    });
+
+    it('should parse an ssh remote', () => {
+      const result = provider.parseUrl('git@github.com:owner/repo.git');
+
+      expect(result.isValid).toBe(true);
+      expect(result.owner).toBe('owner');
+      expect(result.repo).toBe('repo');
+    });
+
     it('should parse basic repo URL', () => {
       const result = provider.parseUrl('https://github.com/facebook/react');
 

--- a/src/features/github/components/GitHubForm.tsx
+++ b/src/features/github/components/GitHubForm.tsx
@@ -45,9 +45,6 @@ export function GitHubForm({ onSubmit, disabled = false }: GitHubFormProps) {
         onClick={handleSubmit}
         className="w-full"
       >
-        <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10" />
-        </svg>
         Load Repository
       </Button>
     </div>

--- a/src/features/github/components/GitHubUrlInput.tsx
+++ b/src/features/github/components/GitHubUrlInput.tsx
@@ -104,20 +104,23 @@ export function GitHubUrlInput({ onValidUrl, onUrlChange, hideSubmitButton = fal
           <ul className="text-blue-700 dark:text-blue-300 space-y-1 list-disc list-inside">
             <li>
               <code className="text-xs bg-blue-100 dark:bg-blue-800 px-1 py-0.5 rounded">
-                https://github.com/owner/repo
+                github.com/owner/repo
               </code>
             </li>
             <li>
               <code className="text-xs bg-blue-100 dark:bg-blue-800 px-1 py-0.5 rounded">
-                https://github.com/owner/repo/tree/branch
+                github.com/owner/repo/tree/branch
               </code>
             </li>
             <li>
               <code className="text-xs bg-blue-100 dark:bg-blue-800 px-1 py-0.5 rounded">
-                https://github.com/owner/repo/tree/branch/path/to/folder
+                github.com/owner/repo/tree/branch/path/to/folder
               </code>
             </li>
           </ul>
+          <p className="text-xs text-blue-700 dark:text-blue-300">
+            The scheme is optional, and ssh remotes work too.
+          </p>
         </div>
       )}
 
@@ -125,7 +128,8 @@ export function GitHubUrlInput({ onValidUrl, onUrlChange, hideSubmitButton = fal
         <div className="flex gap-2">
           <div className="flex-1">
             <input
-              type="url"
+              type="text"
+              inputMode="url"
               id="github-url"
               value={url}
               onChange={handleUrlChange}

--- a/src/features/github/components/__tests__/GitHubUrlInput.test.tsx
+++ b/src/features/github/components/__tests__/GitHubUrlInput.test.tsx
@@ -177,7 +177,7 @@ describe('GitHubUrlInput', () => {
 
     const input = screen.getByPlaceholderText('https://github.com/facebook/react');
     expect(input).toHaveAttribute('id', 'github-url');
-    expect(input).toHaveAttribute('type', 'url');
+    expect(input).toHaveAttribute('inputmode', 'url');
   });
 
   it('should mark input as invalid when error is present', async () => {

--- a/src/lib/providers/BaseProvider.ts
+++ b/src/lib/providers/BaseProvider.ts
@@ -12,7 +12,7 @@ import type {
   FetchOptions,
 } from '@/types';
 import type { IProvider, ParsedRepoInfo, RateLimiterConfig } from './types';
-import { ProviderError, ErrorCode } from './types';
+import { HttpError, ProviderError, ErrorCode } from './types';
 
 export abstract class BaseProvider implements IProvider {
   protected credentials: ProviderCredentials | null = null;
@@ -134,21 +134,77 @@ export abstract class BaseProvider implements IProvider {
     options?: RequestInit,
     attempt = 1
   ): Promise<Response> {
+    const maxAttempts = this.rateLimiter.retries || 3;
+    let response: Response;
+
     try {
-      const response = await fetch(url, options);
-
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      }
-
-      return response;
+      response = await fetch(url, options);
     } catch (error) {
-      if (attempt < (this.rateLimiter.retries || 3)) {
-        await this.delay(this.rateLimiter.retryDelayMs || 1000);
+      // Connection level failures are worth another attempt
+      if (attempt < maxAttempts) {
+        await this.delay((this.rateLimiter.retryDelayMs || 1000) * attempt);
         return this.fetchWithRetry(url, options, attempt + 1);
       }
       throw error;
     }
+
+    if (response.ok) {
+      return response;
+    }
+
+    const httpError = await this.buildHttpError(response);
+
+    // Retrying a rejected request only spends more of the quota that rejected it
+    if (this.isRetryable(httpError) && attempt < maxAttempts) {
+      const waitMs = httpError.retryAfterSeconds
+        ? httpError.retryAfterSeconds * 1000
+        : (this.rateLimiter.retryDelayMs || 1000) * attempt;
+      await this.delay(waitMs);
+      return this.fetchWithRetry(url, options, attempt + 1);
+    }
+
+    throw httpError;
+  }
+
+  /**
+   * Turn a failed response into an error that carries the status and whatever the API said
+   */
+  protected async buildHttpError(response: Response): Promise<HttpError> {
+    let apiMessage: string | undefined;
+
+    try {
+      const body = await response.text();
+      if (body) {
+        const data = JSON.parse(body);
+        if (typeof data?.message === 'string') {
+          apiMessage = data.message;
+        }
+      }
+    } catch {
+      // A body that is missing or is not JSON tells us nothing extra
+    }
+
+    const retryAfter = Number(response.headers.get('retry-after'));
+    const reset = Number(response.headers.get('x-ratelimit-reset'));
+    const remainingHeader = response.headers.get('x-ratelimit-remaining');
+    const remaining = remainingHeader === null ? NaN : Number(remainingHeader);
+
+    return new HttpError(
+      response.status,
+      apiMessage || response.statusText || undefined,
+      Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter : undefined,
+      Number.isFinite(reset) && reset > 0 ? new Date(reset * 1000) : undefined,
+      Number.isFinite(remaining) ? remaining : undefined
+    );
+  }
+
+  /**
+   * Server faults and short throttles are transient, client errors are not
+   */
+  protected isRetryable(error: HttpError): boolean {
+    if (error.status >= 500) return true;
+    if (error.retryAfterSeconds !== undefined) return error.retryAfterSeconds <= 10;
+    return error.status === 429;
   }
 
   /**
@@ -159,6 +215,56 @@ export abstract class BaseProvider implements IProvider {
 
     if (error instanceof ProviderError) {
       return error;
+    }
+
+    if (error instanceof HttpError) {
+      const detail = error.apiMessage ? `\n\n${error.apiMessage}` : '';
+
+      if (error.status === 401) {
+        return new ProviderError(
+          error.message,
+          ErrorCode.AUTH_FAILED,
+          `Authentication failed${contextMsg}. The access token is missing, expired, or lacks permission for this repository.${detail}`
+        );
+      }
+
+      if (error.status === 404) {
+        return new ProviderError(
+          error.message,
+          ErrorCode.NOT_FOUND,
+          `Resource not found${contextMsg}. Please check the URL and try again.${detail}`
+        );
+      }
+
+      if (error.status === 403) {
+        return new ProviderError(
+          error.message,
+          ErrorCode.AUTH_FAILED,
+          `Access denied${contextMsg}. Please check your credentials or token.${detail}`
+        );
+      }
+
+      if (error.status === 429) {
+        return new ProviderError(
+          error.message,
+          ErrorCode.RATE_LIMITED,
+          `Rate limit exceeded${contextMsg}. Please wait a moment and try again.${detail}`
+        );
+      }
+
+      if (error.status >= 500) {
+        return new ProviderError(
+          error.message,
+          ErrorCode.NETWORK_ERROR,
+          `The service returned an error (HTTP ${error.status})${contextMsg}. Please try again in a moment.${detail}`
+        );
+      }
+
+      return new ProviderError(
+        error.message,
+        ErrorCode.UNKNOWN,
+        `The request failed with HTTP ${error.status}${contextMsg}.${detail}`
+      );
     }
 
     if (error instanceof Error) {

--- a/src/lib/providers/BaseProvider.ts
+++ b/src/lib/providers/BaseProvider.ts
@@ -202,9 +202,9 @@ export abstract class BaseProvider implements IProvider {
    * Server faults and short throttles are transient, client errors are not
    */
   protected isRetryable(error: HttpError): boolean {
-    if (error.status >= 500) return true;
+    // A wait the server asks for decides the matter, however the request failed
     if (error.retryAfterSeconds !== undefined) return error.retryAfterSeconds <= 10;
-    return error.status === 429;
+    return error.status >= 500 || error.status === 429;
   }
 
   /**

--- a/src/lib/providers/types.ts
+++ b/src/lib/providers/types.ts
@@ -122,6 +122,23 @@ export class ProviderError extends Error {
 }
 
 /**
+ * Failed HTTP response, carrying what the API said about it
+ * The message keeps the "HTTP {status}" prefix so providers can match on it
+ */
+export class HttpError extends Error {
+  constructor(
+    public status: number,
+    public apiMessage?: string,
+    public retryAfterSeconds?: number,
+    public rateLimitReset?: Date,
+    public rateLimitRemaining?: number
+  ) {
+    super(`HTTP ${status}${apiMessage ? `: ${apiMessage}` : ''}`);
+    this.name = 'HttpError';
+  }
+}
+
+/**
  * Common error codes
  */
 export enum ErrorCode {

--- a/src/lib/utils/repoName.ts
+++ b/src/lib/utils/repoName.ts
@@ -2,6 +2,8 @@
  * Utility functions for extracting repository names from various sources
  */
 
+import { GitHubProvider } from '@/features/github/GitHubProvider';
+
 /**
  * Sanitize a filename by removing invalid characters
  */
@@ -23,7 +25,7 @@ export function sanitizeFilename(name: string): string {
  */
 export function extractGitHubRepoName(url: string): string {
   try {
-    const urlObj = new URL(url);
+    const urlObj = new URL(GitHubProvider.normalizeUrl(url));
     const parts = urlObj.pathname.split('/').filter(Boolean);
 
     if (parts.length >= 2) {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -22,7 +22,7 @@
   }
 
   body {
-    @apply bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100;
+    @apply bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 antialiased;
     font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   }
 }


### PR DESCRIPTION
(TLDR: replacing most of the ai slop with better ai slop and polishing UX)

Rebuilds the v2 workspace around the file tree and fixes the defects found along the way.

## Fixes

- **File rows misaligned with their parent.** Only directories rendered a disclosure control, so a file sat a control width left of its sibling directories and read as one level up. Every row now reserves the slot; one guide line per ancestor level shows depth.
- **`github.com/owner/repo` rejected as malformed.** URLs are normalised before validation, covering a missing scheme, `www.`, ssh remotes, `.git` suffixes and whitespace. The field was also `type="url"`, applying the browser's scheme rule on top of ours.
- **Ignore-pattern suggestions appended duplicates.** A suggestion now adds its pattern once, shows that it is applied, and removes it on a second click.
- **Unmodelled API statuses surfaced as "An unexpected error occurred".** Failed responses now carry status, message and rate-limit headers, so an expired token reads as one and an exhausted quota says each file costs a request and when the limit resets.
- **Every rejection retried three times**, spending three requests of the quota that had just refused one. Retries are now limited to connection faults, 5xx and short throttles.
- **Excluded-files setting read from a stale closure** when generating output.
- **Tokens entered after loading a repository never reached the provider.** Stored credentials are re-read before each round of requests.
- **Extension summary counted only fully selected types**, so mixed selections reported none.

## Layout

- Generate Output moved into a footer bar inside the file tree panel, next to a selection count, instead of floating above the tree it acts on.
- Sections share one panel surface with dividers rather than nested bordered boxes; the page narrows to a single working column.
- Source tabs align on one row with beta markers inline.
- Output totals were reported twice with different figures, since the summary counted the directory tree and the per-file table did not. One set of totals now, with the per-file list behind a disclosure.
- `index.html` shell updated to match the header and lead it replaces.

## Verification

- `npm run ci`: type check clean, 254 unit tests (12 added), lint warnings unchanged from base.
- `npm run build` succeeds.
- Layout and tree checked in both themes at desktop and mobile widths.

### Before
https://github.com/user-attachments/assets/354f6286-de17-4562-a9eb-c1b828c329a7

### After
https://github.com/user-attachments/assets/202ff47d-5b16-4922-8707-a32df771f89d

_Note: agent may have removed or altered wording that was intentionally informal or 'unpolished,' lmk if scope of PR goes beyond what's wanted_ 


*(PR written by Codex)*


